### PR TITLE
Remove username from AuthPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- From the GraphQL APIs `signIn` and `refreshToken`, the username field has
+  been removed from the `AuthPayload` return object. This is due to redundancy
+  as the caller of `signIn` or `refreshToken` already possesses knowledge of
+  the username.
+
 ## [0.5.0] - 2023-05-08
 
 ### Changed
@@ -58,6 +67,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-web/compare/0.5.0...main
 [0.5.0]: https://github.com/petabi/review-web/compare/0.4.1...0.5.0
 [0.4.1]: https://github.com/petabi/review-web/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/petabi/review-web/compare/0.3.0...0.4.0


### PR DESCRIPTION
From the GraphQL APIs `signIn` and `refreshToken`, the username field has been removed from the `AuthPayload` return object. This is due to redundancy as the caller of `signIn` or `refreshToken` already possesses knowledge of the username.