### PR TITLE
Send empty traffic filtering rules to piglet to clear applied rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- change to use `host_id` instead of `agent_id@host_id` to manage
+  traffic filtering rules.
+- change to send empty traffic filtering rules to `piglet` to clear
+  the applied rules.
+
 ## [0.8.0] - 2023-05-18
 
 ### Added

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -69,7 +69,7 @@ pub trait AgentManager: Send + Sync {
     async fn send_and_recv(&self, key: &str, msg: &[u8]) -> Result<Vec<u8>, anyhow::Error>;
     async fn update_traffic_filter_rules(
         &self,
-        key: &str,
+        host: &str,
         rules: &[(IpNet, Option<Vec<u16>>, Option<Vec<u16>>)],
     ) -> Result<(), anyhow::Error>;
 }


### PR DESCRIPTION
* Change to send empty rules to `Piglet` to clear applied traffic filtering rules
* Change to use `host_id` instead of `agent_id@host_id` to manage traffic filtering rules