### PR TITLE
Broadcast internal/allow/block networks to all Hogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - The `DomainGenerationAlgorithm` event in our `GraphQL` API query now includes
   a confidence field. This field will allow users to access and gauge the
   predictive certainty of the output.
+- Add function to broadcast `internal/allow/block networks` to all Hogs.
+  - `Internal networks` is the networks of customer assigned to review node.
+  - When new node with review is inserted, the customer networks of the node
+    is broadcasted.
+  - When the customer of review node is changed, the networks of new customer
+    is broadcasted.
+  - When the customer networks of review node is changed, the changed networks
+    is broadcasted.
+  - `Internal networks` includes all of the `Intranet`, `Extranet`, `Gateway`
+    addresses of customer.
 
 ## [0.9.0] - 2023-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,37 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - The `DomainGenerationAlgorithm` event in our `GraphQL` API query now includes
   a confidence field. This field will allow users to access and gauge the
   predictive certainty of the output.
-- Add function to broadcast `internal/allow/block networks` to all Hogs.
-  - `Internal networks` is the networks of customer assigned to review node.
-  - When new node with review is inserted, the customer networks of the node
-    is broadcasted.
-  - When the customer of review node is changed, the networks of new customer
-    is broadcasted.
-  - When the customer networks of review node is changed, the changed networks
-    is broadcasted.
-  - `Internal networks` includes all of the `Intranet`, `Extranet`, `Gateway`
-    addresses of customer.
+- `AgentManager` trait has been extended with three new methods.
+  - `broadcast_internal_networks`: This method is responsible for broadcasting
+    the customer's network details, including intranet, extranet, and gateway
+    IP addresses to clients.
+  - `broadcast_allow_networks`: This method sends the IP addresses that are
+    always accepted as benign to the clients.
+  - `broadcast_block_networks`: This method broadcasts the IP addresses that
+    are always considered suspicious.
+- Four new functions have been added to the `graphql` module to assist with the
+  implementation of the `AgentManager` trait:
+  - `graphql::get_allow_networks`: Fetches the list of IP addresses that are
+    always accepted as benign.
+  - `graphql::get_block_networks`: Fetches the list of IP addresses that are
+    always considered suspicious.
+  - `graphql::get_customer_networks`: Gets the customer's network details,
+    including intranet, extranet, and gateway IP addresses.
+  - `get_customer_id_of_review_host`: Returns the customer ID associated with
+    the review host.
+- Two new GraphQL API methods have been added:
+  - `applyAllowNetworks`: Applies the list of IP addresses that are always
+    accepted as benign.
+  - `applyBlockNetworks`: Applies the list of IP addresses that are always
+    considered suspicious.
+
+### Changed
+
+- The behavior when a new node is added or the customer of a node is changed,
+  has been updated to broadcast the customer networks of the node.
+- If the customer networks of a node are updated, the changes are now
+  broadcast. This provides an additional layer of communication to keep the
+  system up-to-date with changes.
 
 ## [0.9.0] - 2023-05-22
 

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -68,6 +68,17 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
+    async fn broadcast_internal_networks(&self, _networks: &[u8]) -> Result<Vec<String>, Error> {
+        bail!("Not supported")
+    }
+    async fn broadcast_allow_networks(&self, _networks: &[u8]) -> Result<Vec<String>, Error> {
+        bail!("Not supported")
+    }
+
+    async fn broadcast_block_networks(&self, _networks: &[u8]) -> Result<Vec<String>, Error> {
+        bail!("Not supported")
+    }
+
     async fn online_apps_by_host_id(
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, Error> {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -33,8 +33,11 @@ mod traffic_filter;
 mod triage;
 mod trusted_domain;
 
+pub use self::allow_network::get_allow_networks;
+pub use self::block_network::get_block_networks;
 pub use self::cert::ParsedCertificate;
-pub use self::node::get_node_settings;
+pub use self::customer::get_customer_networks;
+pub use self::node::{get_customer_id_of_review_host, get_node_settings};
 use async_graphql::{
     connection::{Connection, Edge, EmptyFields},
     Context, EmptySubscription, Guard, MergedObject, ObjectType, OutputType, Result,
@@ -63,6 +66,18 @@ pub(super) type Schema = async_graphql::Schema<Query, Mutation, EmptySubscriptio
 pub trait AgentManager: Send + Sync {
     async fn broadcast_to_crusher(&self, message: &[u8]) -> Result<(), anyhow::Error>;
     async fn broadcast_trusted_domains(&self) -> Result<(), anyhow::Error>;
+    async fn broadcast_internal_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error>;
+    async fn broadcast_allow_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error>;
+    async fn broadcast_block_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error>;
     async fn online_apps_by_host_id(
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
@@ -476,6 +491,28 @@ impl AgentManager for MockAgentManager {
     }
     async fn broadcast_trusted_domains(&self) -> Result<(), anyhow::Error> {
         unimplemented!()
+    }
+    async fn broadcast_internal_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error> {
+        Ok(vec!["hog@hostA".to_string()])
+    }
+    async fn broadcast_allow_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error> {
+        Ok(vec!["hog@hostA".to_string(), "hog@hostB".to_string()])
+    }
+    async fn broadcast_block_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error> {
+        Ok(vec![
+            "hog@hostA".to_string(),
+            "hog@hostB".to_string(),
+            "hog@hostC".to_string(),
+        ])
     }
     async fn online_apps_by_host_id(
         &self,

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -6,7 +6,7 @@ mod status;
 use async_graphql::{types::ID, ComplexObject, Context, InputObject, Object, Result, SimpleObject};
 use bincode::Options;
 use chrono::{DateTime, Utc};
-pub use crud::get_node_settings;
+pub use crud::{get_customer_id_of_review_host, get_node_settings};
 use input::NodeInput;
 use ipnet::Ipv4Net;
 use review_database::{Indexable, Indexed, Store};


### PR DESCRIPTION
* Add function to broadcast internal/allow/block networks to all Hogs
* `internal networks` is the networks of customer assigned to review node
  - When a new node with review is inserted, the customer networks of the node is broadcasted.
  - When the customer of review node is changed, the networks of new customer is broadcasted.
  - When the customer networks of review node is changed, the changed networks is broadcasted.
  - `internal networks` includes all of the `Intranet`, `Extranet`, `Gateway` addresses of customer.
 
The networks are defined as following:
```rust
struct HostNetworkGroup {
    hosts: Vec<IpAddr>,
    networks: Vec<IpNet>,
    ip_ranges: Vec<RangeInclusive<IpAddr>>,
}
```