### PR TITLE
fix broadcast internal networks, allow/block list values to hog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Change to serialize values with `bincode::DefaultOptions::new().serialize()`
+  instead of `bincode::serialize()` when broadcasting
+  `internal networks, allow/block list`
+
 ## [0.10.0] - 2023-05-31
 
 ### Added

--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -119,7 +119,8 @@ impl AllowNetworkMutation {
         .or(RoleGuard::new(Role::SecurityAdministrator))")]
     async fn apply_allow_networks(&self, ctx: &Context<'_>) -> Result<Vec<String>> {
         let db = ctx.data::<Arc<Store>>()?;
-        let serialized_networks = bincode::serialize(&get_allow_networks(db)?)?;
+        let serialized_networks =
+            bincode::DefaultOptions::new().serialize(&get_allow_networks(db)?)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
             .broadcast_allow_networks(&serialized_networks)

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -119,7 +119,8 @@ impl BlockNetworkMutation {
         .or(RoleGuard::new(Role::SecurityAdministrator))")]
     async fn apply_block_networks(&self, ctx: &Context<'_>) -> Result<Vec<String>> {
         let db = ctx.data::<Arc<Store>>()?;
-        let serialized_networks = bincode::serialize(&get_block_networks(db)?)?;
+        let serialized_networks =
+            bincode::DefaultOptions::new().serialize(&get_block_networks(db)?)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
             .broadcast_block_networks(&serialized_networks)

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -571,7 +571,7 @@ pub async fn broadcast_customer_networks(
     ctx: &Context<'_>,
     networks: &database::HostNetworkGroup,
 ) -> Result<Vec<String>> {
-    let networks = bincode::serialize(&networks)?;
+    let networks = bincode::DefaultOptions::new().serialize(&networks)?;
     let agent_manager = ctx.data::<BoxedAgentManager>()?;
     agent_manager
         .broadcast_internal_networks(&networks)

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -328,6 +328,7 @@ impl SamplingPolicyMutation {
             if let Err(e) = agents.broadcast_to_crusher(&msg).await {
                 // Change policy to mutable so that user can retry
                 let old = SamplingPolicyInput::try_from(pol)?;
+                #[allow(clippy::redundant_clone)]
                 let mut new = old.clone();
                 new.immutable = false;
                 let db = ctx.data::<Arc<Store>>()?;


### PR DESCRIPTION
Fix broadcast internet networks, allow/block list values to serialize with `bincode::DefaultOptions::new()`