### PR TITLE
Add fields to `NodeStatus` and `Event`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added new fields to the `Event` enum internal struct provided via GraphQL for
+enhanced `detect event filtering`. This will allow more detailed filtering
+capabilities in the GraphQL API.
+- Introduced a `ping` field to `NodeStatus` struct, accessible via the
+`NodeStatusList` query. As part of this change, we updated the `status::load`
+function to include the `ping` field in the response of the `NodeStatusList`
+query. This enhancement allows users to retrieve the `ping` status of nodes
+using the GraphQL API.
+- Updated the `status::load` function to include the `ping` field in the
+response of the `NodeStatusList` query. This change enables users to retrieve
+the `ping` status of nodes via the GraphQL API.
+
 ### Changed
 
-- Change to serialize values with `bincode::DefaultOptions::new().serialize()`
-  instead of `bincode::serialize()` when broadcasting
-  `internal networks, allow/block list`
+- Modified serialization method in broadcasting of `internal networks,
+allow/block list`. The new implementation now uses
+`bincode::DefaultOptions::new().serialize()` instead of `bincode::serialize()`.
+This change is aimed at maintaining consistency with other serialized data
+across our system.
 
 ## [0.10.0] - 2023-05-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-web"
-version = "0.10.0"
+version = "0.10.1-alpha.1"
 edition = "2021"
 
 [dependencies]
@@ -21,7 +21,7 @@ ipnet = { version = "2", features = ["serde"] }
 jsonwebtoken = "8"
 lazy_static = "1"
 num-traits = "0.2"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.7.0" }
+oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.8.1" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -302,6 +302,10 @@ impl DnsCovertChannel {
         &self.inner.source
     }
 
+    async fn session_end_time(&self) -> DateTime<Utc> {
+        self.inner.session_end_time
+    }
+
     async fn src_addr(&self) -> String {
         self.inner.src_addr.to_string()
     }
@@ -358,6 +362,50 @@ impl DnsCovertChannel {
 
     async fn query(&self) -> &str {
         &self.inner.query
+    }
+
+    async fn answer(&self) -> Vec<String> {
+        self.inner.answer.clone()
+    }
+
+    async fn trans_id(&self) -> u16 {
+        self.inner.trans_id
+    }
+
+    async fn rtt(&self) -> i64 {
+        self.inner.rtt
+    }
+
+    async fn qclass(&self) -> u16 {
+        self.inner.qclass
+    }
+
+    async fn qtype(&self) -> u16 {
+        self.inner.qtype
+    }
+
+    async fn rcode(&self) -> u16 {
+        self.inner.rcode
+    }
+
+    async fn aa_flag(&self) -> bool {
+        self.inner.aa_flag
+    }
+
+    async fn tc_flag(&self) -> bool {
+        self.inner.tc_flag
+    }
+
+    async fn rd_flag(&self) -> bool {
+        self.inner.rd_flag
+    }
+
+    async fn ra_flag(&self) -> bool {
+        self.inner.ra_flag
+    }
+
+    async fn ttl(&self) -> Vec<i32> {
+        self.inner.ttl.clone()
     }
 
     async fn confidence(&self) -> f32 {
@@ -741,6 +789,10 @@ impl TorConnection {
         &self.inner.source
     }
 
+    async fn session_end_time(&self) -> DateTime<Utc> {
+        self.inner.session_end_time
+    }
+
     async fn src_addr(&self) -> String {
         self.inner.src_addr.to_string()
     }
@@ -793,6 +845,70 @@ impl TorConnection {
     async fn dst_network(&self, ctx: &Context<'_>) -> Result<Option<Network>> {
         let map = ctx.data::<Arc<Store>>()?.network_map();
         find_ip_network(&map, self.inner.dst_addr)
+    }
+
+    async fn host(&self) -> &str {
+        &self.inner.host
+    }
+
+    async fn method(&self) -> &str {
+        &self.inner.method
+    }
+
+    async fn uri(&self) -> &str {
+        &self.inner.uri
+    }
+
+    async fn referer(&self) -> &str {
+        &self.inner.referrer
+    }
+
+    async fn version(&self) -> &str {
+        &self.inner.version
+    }
+
+    async fn user_agent(&self) -> &str {
+        &self.inner.user_agent
+    }
+
+    async fn request_len(&self) -> usize {
+        self.inner.request_len
+    }
+
+    async fn response_len(&self) -> usize {
+        self.inner.response_len
+    }
+
+    async fn status_code(&self) -> u16 {
+        self.inner.status_code
+    }
+
+    async fn status_msg(&self) -> &str {
+        &self.inner.status_msg
+    }
+
+    async fn username(&self) -> &str {
+        &self.inner.username
+    }
+
+    async fn password(&self) -> &str {
+        &self.inner.password
+    }
+
+    async fn cookie(&self) -> &str {
+        &self.inner.cookie
+    }
+
+    async fn content_encoding(&self) -> &str {
+        &self.inner.content_encoding
+    }
+
+    async fn content_type(&self) -> &str {
+        &self.inner.content_type
+    }
+
+    async fn cache_control(&self) -> &str {
+        &self.inner.cache_control
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -235,6 +235,9 @@ pub(super) struct NodeStatus {
     /// The total disk space in bytes that is currently used.
     used_disk_space: Option<u64>,
 
+    /// The ping value for a specific node.
+    ping: Option<i64>,
+
     /// Whether review is online or not.
     review: Option<bool>,
 
@@ -268,6 +271,7 @@ impl NodeStatus {
         used_memory: Option<u64>,
         total_disk_space: Option<u64>,
         used_disk_space: Option<u64>,
+        ping: Option<i64>,
         review: Option<bool>,
         piglet: Option<bool>,
         giganto: Option<bool>,
@@ -282,6 +286,7 @@ impl NodeStatus {
             used_memory,
             total_disk_space,
             used_disk_space,
+            ping,
             review,
             piglet,
             giganto,


### PR DESCRIPTION
- Added the fields of the `Event` enum internal struct provided via GraphQL. The added fields are used for more detailed `detect event filtering`.
- Added a `ping` field to `NodeStatus` struct. The added fields are available through the `NodeStatusList` query.
- Modify `status::laod` function so that the `NodeStatusList` query returns a ping field.

reference: https://github.com/aicelab/sasui/issues/2