### PR TITLE
change serialize method

### DIFF
--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -120,7 +120,8 @@ impl AllowNetworkMutation {
     async fn apply_allow_networks(&self, ctx: &Context<'_>) -> Result<Vec<String>> {
         let store = crate::graphql::get_store(ctx).await?;
 
-        let serialized_networks = bincode::serialize(&get_allow_networks(&store)?)?;
+        let serialized_networks =
+            bincode::DefaultOptions::new().serialize(&get_allow_networks(&store)?)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
             .broadcast_allow_networks(&serialized_networks)

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -121,7 +121,8 @@ impl BlockNetworkMutation {
         .or(RoleGuard::new(Role::SecurityAdministrator))")]
     async fn apply_block_networks(&self, ctx: &Context<'_>) -> Result<Vec<String>> {
         let db = super::get_store(ctx).await?;
-        let serialized_networks = bincode::serialize(&get_block_networks(&db)?)?;
+        let serialized_networks =
+            bincode::DefaultOptions::new().serialize(&get_block_networks(&db)?)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
             .broadcast_block_networks(&serialized_networks)


### PR DESCRIPTION
Hog use `bincode::DefaultOptions::new().deserialize()` method to deserialize the broadcasted internal network/allow/block list from REview.

I changed this last week but it's overwrited. Now I recover the change.