### PR TITLE
Modify the type of port to u16 of TorConnection and RepeatedHttpSessions event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `apply_trusted_user_agent`: Apply a list of trusted user agent to the all
     `hog` associated with `REview`.
 
+### Changed
+
+- Modify the type of `port` to `u16` of `TorConnection` and `RepeatedHttpSessions`.
+
 ## [0.13.1] - 2023-06-16
 
 ### Fixed

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -724,8 +724,8 @@ impl RepeatedHttpSessions {
         self.inner.src_addr.to_string()
     }
 
-    async fn src_port(&self) -> String {
-        self.inner.src_port.to_string()
+    async fn src_port(&self) -> u16 {
+        self.inner.src_port
     }
 
     /// The two-letter country code of the source IP address. `"XX"` if the
@@ -751,8 +751,8 @@ impl RepeatedHttpSessions {
         self.inner.dst_addr.to_string()
     }
 
-    async fn dst_port(&self) -> String {
-        self.inner.dst_port.to_string()
+    async fn dst_port(&self) -> u16 {
+        self.inner.dst_port
     }
 
     async fn proto(&self) -> u8 {
@@ -814,8 +814,8 @@ impl TorConnection {
         self.inner.src_addr.to_string()
     }
 
-    async fn src_port(&self) -> String {
-        self.inner.src_port.to_string()
+    async fn src_port(&self) -> u16 {
+        self.inner.src_port
     }
 
     /// The two-letter country code of the source IP address. `"XX"` if the
@@ -841,8 +841,8 @@ impl TorConnection {
         self.inner.dst_addr.to_string()
     }
 
-    async fn dst_port(&self) -> String {
-        self.inner.dst_port.to_string()
+    async fn dst_port(&self) -> u16 {
+        self.inner.dst_port
     }
 
     async fn proto(&self) -> u8 {


### PR DESCRIPTION
To maintain consistency, change the type of `port` number to `u16` from `String`.
* `TorConnection` and `RepeatedHttpSessions` event