### PR TITLE
Added `rankedOutlierStream` Graphql API to fetch `ranked outlier` periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `ranked_outlier_stream` Graphql API to fetch `RankedOutlier` periodically.
+  - Gets the id of the currently stored `Model`.
+  - Generate a `RankedOutlier` iterator corresponding to the prefix of the
+    `Model`'s id. If not first fetch, generate iterator since the last fetched key.
+  - Stream through the `RankedOutlier` iterator, and repeat the behavior after a
+    period of time.
+
 ## [0.15.0] - 2023-11-15
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-web"
-version = "0.15.0"
+version = "0.15.1-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -229,7 +229,7 @@ pub(super) struct Mutation(
 
 /// A set of subscription defined in the schema.
 #[derive(MergedSubscription, Default)]
-pub(super) struct Subscription(event::EventStream);
+pub(super) struct Subscription(event::EventStream, outlier::OutlierStream);
 
 #[derive(Debug)]
 pub struct ParseEnumError;

--- a/src/graphql/data_source.rs
+++ b/src/graphql/data_source.rs
@@ -49,8 +49,8 @@ pub(super) struct DataSourceInsertInput {
 }
 
 impl DataSourceInsertInput {
-    const DEFAULT_DATA_SOURCE_ADDRESS: &str = "127.0.0.1:38371";
-    const DEFAULT_SERVER_NAME: &str = "localhost";
+    const DEFAULT_DATA_SOURCE_ADDRESS: &'static str = "127.0.0.1:38371";
+    const DEFAULT_SERVER_NAME: &'static str = "localhost";
 }
 
 impl TryFrom<DataSourceInsertInput> for database::DataSource {


### PR DESCRIPTION
Added a grapqhl subscription to periodically send the stored `ranked outliers`. 
This feature is currently used by `L Project` to transfer all the `ranked outliers` stored on the lower server to the upper server, but it is necessary because we will need this structure in our product in the future.