### PR TITLE
[WIP] Replace `tracing` to `log-broker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - The timestamp is now added to the return value field `batch_ts`, representing
     the batch timestamp for the specified `Statistics`.
   - The returned `Statistics` are now sorted according to `batch_ts` and `column_index`.
+- Replaced `tracing` with `log-broker`
+  - To use `log-broker`, `redis_log_addr`, `redis_log_client_id` are required in
+    the configuration file.
 
 ## [0.15.0] - 2023-11-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ip2location = "0.5"
 ipnet = { version = "2", features = ["serde"] }
 jsonwebtoken = "9"
 lazy_static = "1"
+log-broker = { git = "https://github.com/aicers/log-broker.git", tag = "0.1.0" }
 num-traits = "0.2"
 oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.1" }
 reqwest = { version = "0.11", default-features = false, features = [
@@ -35,7 +36,6 @@ serde_json = "1"
 thiserror = "1"
 tokio = "1"
 tower-http = { version = "0.4", features = ["fs", "trace"] }
-tracing = "0.1"
 vinum = { git = "https://github.com/vinesystems/vinum.git", tag = "1.0.3" }
 
 [dev-dependencies]
@@ -43,8 +43,6 @@ config = { version = "0.13", features = ["toml"], default-features = false }
 futures = "0.3"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[example]]
 name = "minireview"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ htdocs_dir = "/path/to/htdocs"              # path to a directory for web files
 ip2location = "/path/to/IP2LOCATON"         # path to a IP2LOCATION file
 key = "/path/to/key.pem"                    # path to a key file
 log_dir = "/path/to/log"                    # path to a log directory
+redis_log_addr = "127.0.0.1:6379"           # address to redis server
+redis_log_agent_id = "review@localhost"     # agent id to send log to redis server
 
 [[reverse_proxies]]
 base = "archive"                            # proxy name for Giganto

--- a/src/graphql/account.rs
+++ b/src/graphql/account.rs
@@ -6,6 +6,7 @@ use async_graphql::{
 };
 use bincode::Options;
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use log_broker::{info, LogLocation};
 use review_database::{
     self as database,
     types::{self},
@@ -16,7 +17,6 @@ use std::{
     collections::HashSet,
     net::{AddrParseError, IpAddr},
 };
-use tracing::info;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Serialize, SimpleObject)]
@@ -261,17 +261,17 @@ impl AccountMutation {
 
                 insert_token(&store, &token, &username)?;
 
-                info!("{} signed in", username);
+                info!(LogLocation::Both, "{username} signed in");
                 Ok(AuthPayload {
                     token,
                     expiration_time,
                 })
             } else {
-                info!("wrong password for {username}");
+                info!(LogLocation::Both, "wrong password for {username}");
                 Err("incorrect username or password".into())
             }
         } else {
-            info!("{username} is not a valid username");
+            info!(LogLocation::Both, "{username} is not a valid username");
             Err("incorrect username or password".into())
         }
     }
@@ -286,7 +286,7 @@ impl AccountMutation {
         revoke_token(&store, &token)?;
         let decoded_token = decode_token(&token)?;
         let username = decoded_token.sub;
-        info!("{username} signed out");
+        info!(LogLocation::Both, "{username} signed out");
         Ok(token)
     }
 

--- a/src/graphql/cert.rs
+++ b/src/graphql/cert.rs
@@ -1,7 +1,7 @@
 use async_graphql::{Context, Object, Result, SimpleObject};
+use log_broker::{info, LogLocation};
 use std::sync::Arc;
 use tokio::sync::Notify;
-use tracing::info;
 
 use super::{CertManager, Role, RoleGuard};
 
@@ -30,7 +30,10 @@ impl CertMutation {
         cert: String,
         key: String,
     ) -> Result<CertificatePayload> {
-        info!("Received a request to update certificate and private key");
+        info!(
+            LogLocation::Both,
+            "Received a request to update certificate and private key"
+        );
 
         let cert_manager = ctx.data::<Arc<dyn CertManager>>()?;
         let parsed_certs = cert_manager.update_certificate(cert, key)?;

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -7,12 +7,12 @@ use async_graphql::{
 };
 use bincode::Options;
 use chrono::{DateTime, Utc};
+use log_broker::{error, LogLocation};
 use review_database::{
     self as database, types::FromKeyValue, Indexed, IndexedMap, IndexedMapIterator,
     IndexedMapUpdate, IterableMap, Store,
 };
 use std::convert::{TryFrom, TryInto};
-use tracing::error;
 
 #[derive(Default)]
 pub(super) struct CustomerQuery;
@@ -153,7 +153,10 @@ impl CustomerMutation {
             )
             .await
             {
-                error!("failed to broadcast internal networks. {e:?}");
+                error!(
+                    LogLocation::Both,
+                    "failed to broadcast internal networks. {e:?}"
+                );
             }
         }
 
@@ -199,7 +202,10 @@ impl CustomerMutation {
 
         if let Some(networks) = changed_networks {
             if let Err(e) = broadcast_customer_networks(ctx, &networks).await {
-                error!("failed to broadcast internal networks. {e:?}");
+                error!(
+                    LogLocation::Both,
+                    "failed to broadcast internal networks. {e:?}"
+                );
             }
         }
 

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -41,6 +41,7 @@ use bincode::Options;
 use chrono::{DateTime, Utc};
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::stream::Stream;
+use log_broker::{error, warn, LogLocation};
 use num_traits::FromPrimitive;
 use review_database::{
     self as database,
@@ -57,7 +58,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tokio::time;
-use tracing::{error, warn};
 
 const DEFAULT_CONNECTION_SIZE: usize = 100;
 const DEFAULT_EVENT_FETCH_TIME: u64 = 20;
@@ -100,7 +100,7 @@ impl EventStream {
             )
             .await
             {
-                error!("{e:?}");
+                error!(LogLocation::Both, "{e:?}");
             }
         });
         Ok(rx)
@@ -671,7 +671,7 @@ impl EventTotalCount {
             let (key, event) = match item {
                 Ok(kv) => kv,
                 Err(e) => {
-                    warn!("invalid event: {:?}", e);
+                    warn!(LogLocation::Both, "invalid event: {e:?}");
                     continue;
                 }
             };
@@ -1054,7 +1054,7 @@ fn iter_to_events(
         let (key, mut event) = match item {
             Ok(kv) => kv,
             Err(e) => {
-                warn!("invalid event: {:?}", e);
+                warn!(LogLocation::Both, "invalid event: {e:?}");
                 continue;
             }
         };

--- a/src/graphql/event/conn.rs
+++ b/src/graphql/event/conn.rs
@@ -161,7 +161,7 @@ impl MultiHostPortScan {
             *self
                 .inner
                 .dst_addrs
-                .get(0)
+                .first()
                 .expect("has value with internal network"),
         )
     }
@@ -243,7 +243,7 @@ impl ExternalDdos {
             *self
                 .inner
                 .src_addrs
-                .get(0)
+                .first()
                 .expect("has value with internal network"),
         )
     }

--- a/src/graphql/event/group.rs
+++ b/src/graphql/event/group.rs
@@ -2,6 +2,7 @@ use super::{from_filter_input, EventListFilterInput};
 use crate::graphql::{Role, RoleGuard};
 use anyhow::Context as AnyhowContext;
 use async_graphql::{Context, Object, OutputType, Result, SimpleObject};
+use log_broker::{warn, LogLocation};
 use review_database::{
     self as database,
     types::{EventCategory, FromKeyValue},
@@ -12,7 +13,6 @@ use std::{
     num::NonZeroU8,
     sync::{Arc, Mutex},
 };
-use tracing::warn;
 
 #[derive(Default)]
 pub(in crate::graphql) struct EventGroupQuery;
@@ -263,7 +263,7 @@ impl EventGroupQuery {
             let (key, event) = match item {
                 Ok(kv) => kv,
                 Err(e) => {
-                    warn!("invalid event: {:?}", e);
+                    warn!(LogLocation::Both, "invalid event: {e:?}");
                     continue;
                 }
             };
@@ -338,7 +338,7 @@ async fn count_events<T>(
         let (key, event) = match item {
             Ok(kv) => kv,
             Err(e) => {
-                warn!("invalid event: {:?}", e);
+                warn!(LogLocation::Both, "invalid event: {e:?}");
                 continue;
             }
         };
@@ -398,7 +398,7 @@ async fn count_events_by_network(
         let (key, event) = match item {
             Ok(kv) => kv,
             Err(e) => {
-                warn!("invalid event: {:?}", e);
+                warn!(LogLocation::Both, "invalid event: {e:?}");
                 continue;
             }
         };

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -362,6 +362,7 @@ pub struct Setting {
     review: Option<ServerPort>,
 }
 
+#[allow(clippy::struct_field_names)]
 #[derive(Serialize)]
 pub struct ServerAddress {
     web_addr: Option<SocketAddr>,

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -14,12 +14,12 @@ use async_graphql::{
 };
 use bincode::Options;
 use chrono::Utc;
+use log_broker::{error, LogLocation};
 use review_database::{Indexed, IterableMap, Store};
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
-use tracing::error;
 
 #[Object]
 impl NodeQuery {
@@ -270,7 +270,10 @@ impl NodeMutation {
 
             if let Ok(networks) = get_customer_networks(&store, customer_id) {
                 if let Err(e) = broadcast_customer_networks(ctx, &networks).await {
-                    error!("failed to broadcast internal networks. {e:?}");
+                    error!(
+                        LogLocation::Both,
+                        "failed to broadcast internal networks. {e:?}"
+                    );
                 }
             }
         }
@@ -334,7 +337,10 @@ impl NodeMutation {
 
                 if let Ok(networks) = get_customer_networks(&store, customer_id) {
                     if let Err(e) = broadcast_customer_networks(ctx, &networks).await {
-                        error!("failed to broadcast internal networks. {e:?}");
+                        error!(
+                            LogLocation::Both,
+                            "failed to broadcast internal networks. {e:?}"
+                        );
                     }
                 }
             }

--- a/src/graphql/outlier.rs
+++ b/src/graphql/outlier.rs
@@ -17,13 +17,13 @@ use chrono::{offset::LocalResult, DateTime, NaiveDateTime, TimeZone, Utc};
 use data_encoding::BASE64;
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::stream::Stream;
+use log_broker::{error, LogLocation};
 use num_traits::ToPrimitive;
 use review_database::{types::FromKeyValue, Database, Direction, IterableMap, Store};
 use serde::Deserialize;
 use serde::Serialize;
 use std::{cmp, collections::HashMap, sync::Arc};
 use tokio::{sync::RwLock, time};
-use tracing::error;
 
 pub const TIMESTAMP_SIZE: usize = 8;
 const DEFAULT_OUTLIER_SIZE: usize = 50;
@@ -60,7 +60,7 @@ impl OutlierStream {
             )
             .await
             {
-                error!("{e:?}");
+                error!(LogLocation::Both, "{e:?}");
             }
         });
         Ok(rx)

--- a/src/graphql/triage/policy.rs
+++ b/src/graphql/triage/policy.rs
@@ -3,14 +3,12 @@ use super::{
     TriagePolicyMutation, TriagePolicyQuery,
 };
 use super::{Role, RoleGuard};
-use anyhow::anyhow;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, Object, Result, ID,
 };
 use bincode::Options;
 use chrono::Utc;
-use core::convert::TryInto;
 use review_database::{
     self as database, Indexed, IndexedMap, IndexedMapIterator, IndexedMapUpdate,
 };
@@ -103,7 +101,7 @@ impl TriagePolicyMutation {
     ) -> Result<ID> {
         let mut packet_attr_convert: Vec<database::PacketAttr> = Vec::new();
         for p in &packet_attr {
-            packet_attr_convert.push(p.try_into()?);
+            packet_attr_convert.push(p.into());
         }
         packet_attr_convert.sort_unstable();
         let mut ti_db = ti_db.iter().map(Into::into).collect::<Vec<database::Ti>>();
@@ -202,7 +200,7 @@ impl IndexedMapUpdate for TriagePolicyInput {
         value.ti_db = ti_db;
         let mut packet_attr: Vec<database::PacketAttr> = Vec::new();
         for p in &self.packet_attr {
-            packet_attr.push(p.try_into().map_err(|e| anyhow!("{}", e))?);
+            packet_attr.push(p.into());
         }
         packet_attr.sort_unstable();
         value.packet_attr = packet_attr;
@@ -239,9 +237,7 @@ impl IndexedMapUpdate for TriagePolicyInput {
         }
         let mut packet_attr: Vec<database::PacketAttr> = Vec::new();
         for p in &self.packet_attr {
-            if let Ok(p) = p.try_into() {
-                packet_attr.push(p);
-            }
+            packet_attr.push(p.into());
         }
         packet_attr.sort_unstable();
         if packet_attr != value.packet_attr {


### PR DESCRIPTION
- To use `log-broker`, `redis_log_addr`, `redis_log_client_id` are required in the configuration file.
- Fix clippy error

Close: #100