### PR TITLE
Add new graphql qeury (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Added three new GraphQL API methods for triage:
+  - `insert_triage_result`:  This new method store triage result.
+  - `event_list_with_triage`: This new method return event with triage result.
+  - `insert_event_with_triage`: This new method store event and triage result.
+- Added two new GraphQL API methods for rio's ranked outlier:
+  - `insert_central_ranked_outlier`: This new method store `CentralRankedOutlier`.
+  - `central_ranked_outliers`: This new method search `CentralRankedOutlier`.
+- Added three new GraphQL API methods for semi-supervised model:
+  - `semi_model_list`: This new method returns a list of semi-supervised models.
+  - `insert_semi_model`: This new method insert the semi-supervised model into a
+    `semi models` table.
+  - `remove_semi_models`: This new method removes the semi-supervised model from
+    the `semi models` table.
+  - `apply_semi_model`: This new method broadcast the semi-supervised model list
+    to all hogs.
+  - `download_semi_models`: This new method update the `semi models` table with
+    the semi-supervised model downloaded to the relay server.
+- Added `agent_id` for filtering agent id to `EventListWithTriageFilterInput`.
+- Added new fields to the sampling policy's enum Interval.
+  (`FifteenSeconds`, `ThirtySeconds`, `OneMinutes`)
+
 ## [0.17.0] - 2024-01-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-web"
-version = "0.17.0"
+version = "0.17.0-rio.0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -21,11 +21,11 @@ ipnet = { version = "2", features = ["serde"] }
 jsonwebtoken = "9"
 lazy_static = "1"
 num-traits = "0.2"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.1" }
+oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.2" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.23.0" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev ="4cf2c7d" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -68,6 +68,10 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
+    async fn broadcast_semi_model_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
+        bail!("Not supported")
+    }
+
     async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
         bail!("Not supported")
     }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -22,6 +22,7 @@ mod node;
 mod outlier;
 mod qualifier;
 mod sampling;
+mod semi_model;
 mod slicing;
 mod statistics;
 mod status;
@@ -39,6 +40,7 @@ pub use self::block_network::get_block_networks;
 pub use self::cert::ParsedCertificate;
 pub use self::customer::get_customer_networks;
 pub use self::node::{get_customer_id_of_review_host, get_node_settings};
+pub use self::semi_model::{get_semi_model_list, SemiModelInfo};
 pub use self::trusted_user_agent::get_trusted_user_agent_list;
 use async_graphql::{
     connection::{Connection, Edge, EmptyFields},
@@ -81,6 +83,7 @@ pub trait AgentManager: Send + Sync {
         _networks: &[u8],
     ) -> Result<Vec<String>, anyhow::Error>;
     async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error>;
+    async fn broadcast_semi_model_list(&self, _list: &[u8]) -> Result<(), anyhow::Error>;
     async fn online_apps_by_host_id(
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
@@ -185,6 +188,7 @@ pub(super) struct Query(
     triage::TriagePolicyQuery,
     triage::TriageResponseQuery,
     trusted_domain::TrustedDomainQuery,
+    semi_model::SemiModelQuery,
     traffic_filter::TrafficFilterQuery,
     allow_network::AllowNetworkQuery,
     trusted_user_agent::UserAgentQuery,
@@ -204,6 +208,7 @@ pub(super) struct Mutation(
     customer::CustomerMutation,
     data_source::DataSourceMutation,
     db_management::DbManagementMutation,
+    event::EventMutation,
     filter::FilterMutation,
     indicator::IndicatorMutation,
     model::ModelMutation,
@@ -221,7 +226,9 @@ pub(super) struct Mutation(
     tidb::TidbMutation,
     triage::TriagePolicyMutation,
     triage::TriageResponseMutation,
+    triage::TriageMutation,
     trusted_domain::TrustedDomainMutation,
+    semi_model::SemiModelMutation,
     traffic_filter::TrafficFilterMutation,
     allow_network::AllowNetworkMutation,
     trusted_user_agent::UserAgentMutation,
@@ -513,6 +520,9 @@ impl AgentManager for MockAgentManager {
         unimplemented!()
     }
     async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
+        unimplemented!()
+    }
+    async fn broadcast_semi_model_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
         unimplemented!()
     }
     async fn broadcast_internal_networks(

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -39,13 +39,14 @@ use super::{
 use anyhow::{anyhow, bail, Context as AnyhowContext};
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
-    Context, InputObject, Object, Result, Subscription, Union, ID,
+    Context, InputObject, Object, Result, SimpleObject, Subscription, Union, ID,
 };
 use bincode::Options;
 use chrono::{DateTime, Utc};
+use database::EventMessage;
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::stream::Stream;
-use num_traits::FromPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 use review_database::{
     self as database,
     event::RecordType,
@@ -72,6 +73,9 @@ pub(super) struct EventStream;
 
 #[derive(Default)]
 pub(super) struct EventQuery;
+
+#[derive(Default)]
+pub(super) struct EventMutation;
 
 #[Subscription]
 impl EventStream {
@@ -436,6 +440,72 @@ impl EventQuery {
         )
         .await
     }
+
+    /// A list of events with timestamp on or after `start` and before `end`.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+    .or(RoleGuard::new(Role::SecurityAdministrator))
+    .or(RoleGuard::new(Role::SecurityManager))
+    .or(RoleGuard::new(Role::SecurityMonitor))")]
+    async fn event_list_with_triage(
+        &self,
+        ctx: &Context<'_>,
+        filter: EventListWithTriageFilterInput,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<Connection<String, EventWithTriage, EventTotalCount, EmptyFields>> {
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move {
+                load_with_triage(ctx, &filter, after, before, first, last).await
+            },
+        )
+        .await
+    }
+}
+
+#[Object]
+impl EventMutation {
+    /// A list of events with timestamp on or after `start` and before `end`.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+    .or(RoleGuard::new(Role::SecurityAdministrator))
+    .or(RoleGuard::new(Role::SecurityManager))
+    .or(RoleGuard::new(Role::SecurityMonitor))")]
+    async fn insert_event_with_triage(
+        &self,
+        ctx: &Context<'_>,
+        time: DateTime<Utc>,
+        event_kind: i32,
+        fields: Vec<u8>,
+        triage_result: Option<String>,
+    ) -> Result<String> {
+        use tokio::sync::RwLock;
+        let store = ctx.data::<Arc<RwLock<Store>>>()?;
+        let store = store.read().await;
+        let event_db = store.events();
+        let map = store.triage_map();
+
+        let Some(kind) = EventKind::from_i32(event_kind) else {
+            return Err(anyhow!("Failed to convert event_kind: Invalid Event key").into());
+        };
+        let event_message = EventMessage { time, kind, fields };
+        if let Err(e) = event_db.put(&event_message) {
+            error!("{:?}", e);
+        }
+
+        if let Some(result) = triage_result {
+            let key = i128::from(time.timestamp_nanos_opt().unwrap_or_default()) << 64
+                | event_kind.to_i128().expect("should not exceed i128::MAX") << 32;
+            let value = bincode::DefaultOptions::new().serialize(&result)?;
+            map.put(&key.to_be_bytes(), &value)?;
+        }
+
+        Ok("done".to_string())
+    }
 }
 
 /// An endpoint of a network flow. One of `predefined`, `side`, and `custom` is
@@ -446,6 +516,12 @@ pub(super) struct EndpointInput {
     pub(super) direction: Option<TrafficDirection>,
     pub(super) predefined: Option<ID>,
     pub(super) custom: Option<HostNetworkGroupInput>,
+}
+
+#[derive(SimpleObject)]
+struct EventWithTriage {
+    pub event: Event,
+    pub triage_result: Option<String>,
 }
 
 /// An event to report.
@@ -608,6 +684,34 @@ struct EventListFilterInput {
     learning_methods: Option<Vec<LearningMethod>>,
     confidence: Option<f32>,
     triage_policies: Option<Vec<ID>>,
+}
+
+#[derive(InputObject)]
+struct EventListWithTriageFilterInput {
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+    customers: Option<Vec<ID>>,
+    endpoints: Option<Vec<EndpointInput>>,
+    directions: Option<Vec<FlowKind>>,
+    source: Option<String>,
+    destination: Option<String>,
+    keywords: Option<Vec<String>>,
+    network_tags: Option<Vec<ID>>,
+    sensors: Option<Vec<String>>,
+    os: Option<Vec<ID>>,
+    devices: Option<Vec<ID>>,
+    host_names: Option<Vec<String>>,
+    user_ids: Option<Vec<String>>,
+    user_names: Option<Vec<String>>,
+    user_departments: Option<Vec<String>>,
+    countries: Option<Vec<String>>,
+    categories: Option<Vec<u8>>,
+    levels: Option<Vec<u8>>,
+    kinds: Option<Vec<String>>,
+    learning_methods: Option<Vec<LearningMethod>>,
+    confidence: Option<f32>,
+    triage_policies: Option<Vec<ID>>,
+    agent_id: Option<String>,
 }
 
 struct TriageScore<'a> {
@@ -841,6 +945,127 @@ fn from_filter_input(store: &Store, input: &EventListFilterInput) -> anyhow::Res
         sensors,
         input.confidence,
         triage_policies,
+        None,
+    ))
+}
+
+#[allow(clippy::too_many_lines)]
+fn from_triage_filter_input(
+    store: &Store,
+    input: &EventListWithTriageFilterInput,
+) -> anyhow::Result<EventFilter> {
+    let customers = if let Some(customers_input) = input.customers.as_deref() {
+        let map = store.customer_map();
+        Some(convert_customer_input(&map, customers_input)?)
+    } else {
+        None
+    };
+
+    let networks = if let Some(endpoints_input) = &input.endpoints {
+        let map = store.network_map();
+        Some(convert_endpoint_input(&map, endpoints_input)?)
+    } else {
+        None
+    };
+
+    let directions = if let Some(directions) = &input.directions {
+        let map = store.customer_map();
+        Some((directions.clone(), internal_customer_networks(&map)?))
+    } else {
+        None
+    };
+
+    let source = if let Some(addr) = &input.source {
+        Some(
+            addr.parse()
+                .map_err(|_| anyhow!("invalid source IP address"))?,
+        )
+    } else {
+        None
+    };
+
+    let destination = if let Some(addr) = &input.destination {
+        Some(
+            addr.parse()
+                .map_err(|_| anyhow!("invalid destination IP address"))?,
+        )
+    } else {
+        None
+    };
+
+    let countries = if let Some(countries_input) = &input.countries {
+        let mut countries = Vec::with_capacity(countries_input.len());
+        for country in countries_input {
+            countries.push(
+                country
+                    .as_bytes()
+                    .try_into()
+                    .context("invalid country code")?,
+            );
+        }
+        Some(countries)
+    } else {
+        None
+    };
+
+    let categories = if let Some(categories_input) = &input.categories {
+        let mut categories = Vec::with_capacity(categories_input.len());
+        for category in categories_input {
+            categories.push(EventCategory::try_from(*category).map_err(|e| anyhow!(e))?);
+        }
+        Some(categories)
+    } else {
+        None
+    };
+
+    let levels = if let Some(levels_input) = &input.levels {
+        let mut levels = Vec::with_capacity(levels_input.len());
+        for level in levels_input {
+            levels.push(NonZeroU8::new(*level).ok_or_else(|| anyhow!("invalid level"))?);
+        }
+        Some(levels)
+    } else {
+        None
+    };
+
+    let kinds = if let Some(kinds_input) = &input.kinds {
+        let mut kinds = Vec::with_capacity(kinds_input.len());
+        for kind in kinds_input {
+            kinds.push(kind.as_str().to_lowercase());
+        }
+        Some(kinds)
+    } else {
+        None
+    };
+
+    let sensors = input.sensors.clone();
+
+    let triage_policies = if let Some(triage_policies) = &input.triage_policies {
+        let map = store.triage_policy_map();
+        Some(convert_triage_input(&map, triage_policies)?)
+    } else {
+        None
+    };
+
+    Ok(EventFilter::new(
+        customers,
+        networks,
+        directions
+            .map(|(kinds, group)| (kinds.into_iter().map(Into::into).collect::<Vec<_>>(), group)),
+        source,
+        destination,
+        countries,
+        categories,
+        levels,
+        kinds,
+        input
+            .learning_methods
+            .as_ref()
+            .map(|v| v.iter().map(|v| (*v).into()).collect()),
+        sensors,
+        input.confidence,
+        triage_policies,
+        input.agent_id.clone(),
     ))
 }
 
@@ -964,6 +1189,53 @@ fn convert_triage_input(
     Ok(triage_policies)
 }
 
+async fn load_with_triage(
+    ctx: &Context<'_>,
+    filter: &EventListWithTriageFilterInput,
+    after: Option<String>,
+    before: Option<String>,
+    first: Option<usize>,
+    last: Option<usize>,
+) -> Result<Connection<String, EventWithTriage, EventTotalCount, EmptyFields>> {
+    let store = crate::graphql::get_store(ctx).await?;
+
+    let start = filter.start;
+    let end = filter.end;
+    let mut filter = from_triage_filter_input(&store, filter)?;
+    filter.moderate_kinds();
+    let db = store.events();
+    let (events, has_previous, has_next) = if let Some(last) = last {
+        let iter = db.iter_from(latest(end, before)?, Direction::Reverse);
+        let to = earliest(start, after)?;
+        let (events, has_more) =
+            iter_to_triage_events(ctx, iter, to, cmp::Ordering::is_ge, last, &filter)
+                .await
+                .map_err(|e| format!("{e}"))?;
+        (events.into_iter().rev().collect(), has_more, false)
+    } else {
+        let first = first.unwrap_or(DEFAULT_CONNECTION_SIZE);
+        let iter = db.iter_from(earliest(start, after)?, Direction::Forward);
+        let to = latest(end, before)?;
+        let (events, has_more) =
+            iter_to_triage_events(ctx, iter, to, cmp::Ordering::is_le, first, &filter)
+                .await
+                .map_err(|e| format!("{e}"))?;
+        (events, false, has_more)
+    };
+
+    let mut connection = Connection::with_additional_fields(
+        has_previous,
+        has_next,
+        EventTotalCount { start, end, filter },
+    );
+    connection.edges.extend(
+        events
+            .into_iter()
+            .map(|(k, ev)| Edge::new(k.to_string(), ev)),
+    );
+    Ok(connection)
+}
+
 async fn load(
     ctx: &Context<'_>,
     filter: &EventListFilterInput,
@@ -1064,6 +1336,77 @@ fn latest_before(before: &str) -> Result<i128> {
         return Err("invalid cursor `before`".into());
     }
     Ok(before - 1)
+}
+
+async fn iter_to_triage_events(
+    ctx: &Context<'_>,
+    iter: EventIterator<'_>,
+    to: i128,
+    cond: fn(cmp::Ordering) -> bool,
+    len: usize,
+    filter: &EventFilter,
+) -> anyhow::Result<(Vec<(i128, EventWithTriage)>, bool)> {
+    let mut events = Vec::new();
+    let mut exceeded = false;
+    let locator = if filter.has_country() {
+        if let Ok(mutex) = ctx.data::<Arc<Mutex<ip2location::DB>>>() {
+            Some(Arc::clone(mutex))
+        } else {
+            bail!("unable to locate IP address");
+        }
+    } else {
+        None
+    };
+
+    let Ok(store) = crate::graphql::get_store(ctx).await else {
+        bail!("Failed to get store");
+    };
+    let map = store.triage_map();
+
+    for item in iter {
+        let (key, mut event) = match item {
+            Ok(kv) => kv,
+            Err(e) => {
+                warn!("invalid event: {:?}", e);
+                continue;
+            }
+        };
+        if !(cond)(key.cmp(&to)) {
+            break;
+        }
+        let triage_score = {
+            let matches = event.matches(locator.clone(), filter)?;
+            if !matches.0 {
+                continue;
+            }
+            matches.1
+        };
+        if let Some(triage_score) = triage_score {
+            event.set_triage_scores(triage_score);
+        }
+
+        let triage_result = if let Some(data) = map.get(&key.to_be_bytes())? {
+            bincode::DefaultOptions::new()
+                .deserialize::<String>(data.as_ref())
+                .ok()
+        } else {
+            None
+        };
+        let event_with_triage = EventWithTriage {
+            event: event.into(),
+            triage_result,
+        };
+
+        events.push((key, event_with_triage));
+        exceeded = events.len() > len;
+        if exceeded {
+            break;
+        }
+    }
+    if exceeded {
+        events.pop();
+    }
+    Ok((events, exceeded))
 }
 
 fn iter_to_events(

--- a/src/graphql/outlier.rs
+++ b/src/graphql/outlier.rs
@@ -116,6 +116,81 @@ async fn fetch_ranked_outliers(
     }
 }
 
+#[derive(Debug, InputObject)]
+pub(super) struct InputCentralRankedOutlier {
+    pub code: String,
+    pub timestamp: String,
+    pub rank: i64,
+    pub id: String,
+    pub source: String,
+    pub distance: f64,
+    pub saved: bool,
+}
+
+#[derive(Debug, SimpleObject)]
+pub(super) struct CentralRankedOutlier {
+    pub code: String,
+    pub timestamp: String,
+    pub rank: i64,
+    pub id: String,
+    pub source: String,
+    pub distance: f64,
+    pub saved: bool,
+}
+
+type CentralRankedOutlierValue = (f64, bool);
+impl FromKeyValue for CentralRankedOutlier {
+    fn from_key_value(key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
+        let (code, timestamp, rank, id, source) =
+            bincode::DefaultOptions::new().deserialize(key)?;
+        let (distance, saved) = bincode::DefaultOptions::new().deserialize(value)?;
+        Ok(Self {
+            code,
+            timestamp,
+            rank,
+            id,
+            source,
+            distance,
+            saved,
+        })
+    }
+}
+
+struct CentralRankedOutlierTotalCount {
+    code: String,
+    timestamp: Option<i64>,
+    check_saved: bool,
+}
+
+#[Object]
+impl CentralRankedOutlierTotalCount {
+    /// The total number of edges.
+    async fn total_count(&self, ctx: &Context<'_>) -> Result<usize> {
+        use review_database::IterableMap;
+        let prefix = if let Some(timestamp) = self.timestamp {
+            bincode::DefaultOptions::new().serialize(&(self.code.clone(), timestamp.to_string()))?
+        } else {
+            bincode::DefaultOptions::new().serialize(&self.code)?
+        };
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.outlier_map().into_prefix_map(&prefix);
+
+        let iter = map.iter_forward()?;
+        let count = if self.check_saved {
+            iter.filter(|(_k, v)| {
+                let (_, saved): CentralRankedOutlierValue = bincode::DefaultOptions::new()
+                    .deserialize(v)
+                    .unwrap_or_default();
+                saved
+            })
+            .count()
+        } else {
+            iter.count()
+        };
+        Ok(count)
+    }
+}
+
 #[derive(Default)]
 pub(super) struct OutlierMutation;
 
@@ -147,6 +222,30 @@ impl OutlierMutation {
         }
 
         Ok(updated.len())
+    }
+
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)")]
+    async fn insert_central_ranked_outlier(
+        &self,
+        ctx: &Context<'_>,
+        input: InputCentralRankedOutlier,
+    ) -> Result<String> {
+        use bincode::Options;
+        let store = super::get_store(ctx).await?;
+        let map = store.outlier_map();
+
+        let key = bincode::DefaultOptions::new().serialize(&(
+            input.code,
+            input.timestamp,
+            input.rank,
+            input.id,
+            input.source,
+        ))?;
+        let value = bincode::DefaultOptions::new().serialize(&(input.distance, input.saved))?;
+        if let Err(e) = map.insert(&key, &value) {
+            return Err(anyhow!("Failed to insert outlier: {:?}", e).into());
+        }
+        Ok("Done".to_string())
     }
 }
 
@@ -246,6 +345,29 @@ impl OutlierQuery {
     ) -> Result<Connection<String, RankedOutlier, RankedOutlierTotalCount, EmptyFields>> {
         load_ranked_outliers_with_filter(ctx, model_id, time, after, before, first, last, filter)
             .await
+    }
+
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+     .or(RoleGuard::new(Role::SecurityAdministrator))
+     .or(RoleGuard::new(Role::SecurityManager))
+     .or(RoleGuard::new(Role::SecurityMonitor))")]
+    #[allow(clippy::too_many_arguments)]
+    async fn central_ranked_outliers(
+        &self,
+        ctx: &Context<'_>,
+        code: String,
+        time: Option<NaiveDateTime>,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<usize>,
+        last: Option<usize>,
+        filter: Option<SearchFilterInput>,
+    ) -> Result<Connection<String, CentralRankedOutlier, CentralRankedOutlierTotalCount, EmptyFields>>
+    {
+        load_central_ranked_outliers_with_filter(
+            ctx, code, time, after, before, first, last, filter,
+        )
+        .await
     }
 }
 
@@ -722,6 +844,256 @@ fn latest_outlier_key(before: &str) -> Result<Vec<u8>> {
         end.push(last_byte - 1);
     }
     Ok(end)
+}
+
+#[allow(clippy::too_many_arguments, clippy::type_complexity)] // since this is called within `load` only
+async fn load_central_ranked_outliers_with_filter(
+    ctx: &Context<'_>,
+    code: String,
+    time: Option<NaiveDateTime>,
+    after: Option<String>,
+    before: Option<String>,
+    first: Option<usize>,
+    last: Option<usize>,
+    filter: Option<SearchFilterInput>,
+) -> Result<Connection<String, CentralRankedOutlier, CentralRankedOutlierTotalCount, EmptyFields>> {
+    let timestamp = time.map(|t| t.timestamp_nanos_opt().unwrap_or_default());
+
+    let prefix = if let Some(timestamp) = timestamp {
+        bincode::DefaultOptions::new().serialize(&(code.clone(), timestamp.to_string()))?
+    } else {
+        bincode::DefaultOptions::new().serialize(&code)?
+    };
+
+    let store = crate::graphql::get_store(ctx).await?;
+    let map = store.outlier_map().into_prefix_map(&prefix);
+    let remarks_map = store.triage_response_map();
+    let tags_map = store.event_tag_set();
+
+    let (nodes, has_previous, has_next) = load_central_nodes_with_search_filter(
+        &map,
+        &remarks_map,
+        &tags_map,
+        &filter,
+        after,
+        before,
+        first,
+        last,
+    )?;
+
+    let mut connection = Connection::with_additional_fields(
+        has_previous,
+        has_next,
+        CentralRankedOutlierTotalCount {
+            code,
+            timestamp,
+            check_saved: false,
+        },
+    );
+    connection
+        .edges
+        .extend(nodes.into_iter().map(|(k, ev)| Edge::new(k, ev)));
+    Ok(connection)
+}
+
+#[allow(clippy::type_complexity, clippy::too_many_arguments)] // since this is called within `load` only
+fn load_central_nodes_with_search_filter<'m, M, I>(
+    map: &'m M,
+    remarks_map: &review_database::IndexedMap<'_>,
+    tags_map: &review_database::IndexedSet<'_>,
+    filter: &Option<SearchFilterInput>,
+    after: Option<String>,
+    before: Option<String>,
+    first: Option<usize>,
+    last: Option<usize>,
+) -> Result<(Vec<(String, CentralRankedOutlier)>, bool, bool)>
+where
+    M: IterableMap<'m, I>,
+    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'm,
+{
+    if let Some(last) = last {
+        let iter = if let Some(before) = before {
+            let end = latest_key(&before)?;
+            map.iter_from(&end, Direction::Reverse)?
+        } else {
+            map.iter_backward()?
+        };
+
+        let (nodes, has_more) = if let Some(after) = after {
+            let to = earliest_key(&after)?;
+            iter_through_search_filter_central_nodes(
+                iter,
+                remarks_map,
+                tags_map,
+                &to,
+                cmp::Ordering::is_ge,
+                filter,
+                last,
+            )
+        } else {
+            iter_through_search_filter_central_nodes(
+                iter,
+                remarks_map,
+                tags_map,
+                &[],
+                always_true,
+                filter,
+                last,
+            )
+        }?;
+        Ok((nodes, has_more, false))
+    } else {
+        let first = first.unwrap_or(DEFAULT_CONNECTION_SIZE);
+        let iter = if let Some(after) = after {
+            let start = earliest_key(&after)?;
+            map.iter_from(&start, Direction::Forward)?
+        } else {
+            map.iter_forward()?
+        };
+
+        let (nodes, has_more) = if let Some(before) = before {
+            let to = latest_key(&before)?;
+            iter_through_search_filter_central_nodes(
+                iter,
+                remarks_map,
+                tags_map,
+                &to,
+                cmp::Ordering::is_le,
+                filter,
+                first,
+            )
+        } else {
+            iter_through_search_filter_central_nodes(
+                iter,
+                remarks_map,
+                tags_map,
+                &[],
+                always_true,
+                filter,
+                first,
+            )
+        }?;
+        Ok((nodes, false, has_more))
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn iter_through_search_filter_central_nodes<I>(
+    iter: I,
+    remarks_map: &review_database::IndexedMap<'_>,
+    tags_map: &review_database::IndexedSet<'_>,
+    to: &[u8],
+    cond: fn(cmp::Ordering) -> bool,
+    filter: &Option<SearchFilterInput>,
+    len: usize,
+) -> Result<(Vec<(String, CentralRankedOutlier)>, bool)>
+where
+    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)>,
+{
+    let mut nodes = Vec::new();
+    let mut exceeded = false;
+
+    let tag_id_list = if let Some(filter) = filter {
+        if let Some(tag) = &filter.tag {
+            let index = tags_map.index()?;
+            let tag_ids: Vec<u32> = index
+                .iter()
+                .filter(|(_, name)| {
+                    let name = String::from_utf8_lossy(name).into_owned();
+                    name.contains(tag)
+                })
+                .map(|(id, _)| id)
+                .collect();
+            if tag_ids.is_empty() {
+                return Ok((nodes, exceeded));
+            }
+            Some(tag_ids)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    for (k, v) in iter {
+        if !(cond)(k.as_ref().cmp(to)) {
+            break;
+        }
+
+        let curser = BASE64.encode(&k);
+        let Some(node) = CentralRankedOutlier::from_key_value(&k, &v)?.into() else {
+            continue;
+        };
+
+        if let Some(filter) = filter {
+            if filter.remark.is_some() || tag_id_list.is_some() {
+                let key = key(&node.source, Utc.timestamp_nanos(node.id.parse::<i64>()?));
+                if let Some(value) = remarks_map.get_by_key(&key)? {
+                    let value: TriageResponse = bincode::DefaultOptions::new()
+                        .deserialize(value.as_ref())
+                        .map_err(|_| "invalid value in database")?;
+                    if let Some(remark) = &filter.remark {
+                        if !value.remarks.contains(remark) {
+                            continue;
+                        }
+                    }
+                    if let Some(tag_ids) = &tag_id_list {
+                        if !tag_ids.iter().any(|tag| value.tag_ids.contains(tag)) {
+                            continue;
+                        }
+                    }
+                } else {
+                    continue;
+                }
+            }
+            if let Some(time) = &filter.time {
+                if let Some(start) = time.start {
+                    if let Some(end) = time.end {
+                        if node.timestamp.parse::<i64>()?
+                            < start.timestamp_nanos_opt().unwrap_or_default()
+                            || node.timestamp.parse::<i64>()?
+                                > end.timestamp_nanos_opt().unwrap_or_default()
+                        {
+                            continue;
+                        }
+                    } else if node.timestamp.parse::<i64>()?
+                        < start.timestamp_nanos_opt().unwrap_or_default()
+                    {
+                        continue;
+                    }
+                } else if let Some(end) = time.end {
+                    if node.timestamp.parse::<i64>()?
+                        > end.timestamp_nanos_opt().unwrap_or_default()
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            if let Some(distance) = &filter.distance {
+                if let Some(start) = distance.start {
+                    if let Some(end) = distance.end {
+                        if node.distance < start || node.distance > end {
+                            continue;
+                        }
+                    } else if (node.distance - start).abs() > DISTANCE_EPSILON {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        nodes.push((curser, node));
+        exceeded = nodes.len() > len;
+        if exceeded {
+            break;
+        }
+    }
+
+    if exceeded {
+        nodes.pop();
+    }
+    Ok((nodes, exceeded))
 }
 
 #[allow(clippy::too_many_arguments, clippy::type_complexity)] // since this is called within `load` only

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -23,11 +23,14 @@ pub(super) struct SamplingPolicyMutation;
 #[derive(Clone, Copy, Eq, PartialEq, Enum, Deserialize, Serialize)]
 #[repr(u32)]
 pub(super) enum Interval {
-    FiveMinutes = 0,
-    TenMinutes = 1,
-    FifteenMinutes = 2,
-    ThirtyMinutes = 3,
-    OneHour = 4,
+    FifteenSeconds = 0,
+    ThirtySeconds = 1,
+    OneMinutes = 2,
+    FiveMinutes = 3,
+    TenMinutes = 4,
+    FifteenMinutes = 5,
+    ThirtyMinutes = 6,
+    OneHour = 7,
 }
 
 impl Default for Interval {

--- a/src/graphql/semi_model.rs
+++ b/src/graphql/semi_model.rs
@@ -1,0 +1,189 @@
+use super::{BoxedAgentManager, Role, RoleGuard};
+use async_graphql::{
+    connection::{query, Connection, EmptyFields},
+    Context, InputObject, Object, Result, SimpleObject,
+};
+use bincode::Options;
+use chrono::{DateTime, Utc};
+use database::types::FromKeyValue;
+use review_database::{self as database, IterableMap, Store};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default)]
+pub(super) struct SemiModelQuery;
+
+#[Object]
+impl SemiModelQuery {
+    /// A list of semi-supervised model list.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+        .or(RoleGuard::new(Role::SecurityAdministrator))
+        .or(RoleGuard::new(Role::SecurityManager))
+        .or(RoleGuard::new(Role::SecurityMonitor))")]
+    async fn semi_model_list(
+        &self,
+        ctx: &Context<'_>,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<Connection<String, SemiModelInfo, SemiModelInfoTotalCount, EmptyFields>> {
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move { load(ctx, after, before, first, last).await },
+        )
+        .await
+    }
+}
+
+#[derive(Default)]
+pub(super) struct SemiModelMutation;
+
+#[Object]
+impl SemiModelMutation {
+    /// Inserts a new semi-supervised model, Returns true if the insertion was successful.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+        .or(RoleGuard::new(Role::SecurityAdministrator))")]
+    async fn insert_semi_model(&self, ctx: &Context<'_>, input_model: SemiModel) -> Result<bool> {
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.semi_models_map();
+
+        let key = input_model.model_name.clone();
+        let value = bincode::serialize::<SemiModelValue>(&(input_model, Utc::now()))?;
+        map.put(key.as_bytes(), &value)?;
+        Ok(true)
+    }
+
+    /// Removes a semi-supervised models using model name , Returns true if the deletion was successful.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+        .or(RoleGuard::new(Role::SecurityAdministrator))")]
+    async fn remove_semi_models(&self, ctx: &Context<'_>, models: Vec<String>) -> Result<bool> {
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.semi_models_map();
+        for model in models {
+            map.delete(model.as_bytes())?;
+        }
+        Ok(true)
+    }
+
+    /// Download semi-supervised models using model name , Returns true if the deletion was successful.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+        .or(RoleGuard::new(Role::SecurityAdministrator))")]
+    async fn download_semi_models(
+        &self,
+        ctx: &Context<'_>,
+        input_models: Vec<SemiModel>,
+    ) -> Result<bool> {
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.semi_models_map();
+
+        let iter = map.iter_forward()?;
+        for (key, _) in iter {
+            map.delete(&key)?;
+        }
+        for model in input_models {
+            let key = model.model_name.clone();
+            let value = bincode::serialize::<SemiModelValue>(&(model, Utc::now()))?;
+            map.put(key.as_bytes(), &value)?;
+        }
+        Ok(true)
+    }
+
+    /// Broadcast the semi-supervised model list to all Hogs.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+        .or(RoleGuard::new(Role::SecurityAdministrator))")]
+    async fn apply_semi_model(&self, ctx: &Context<'_>) -> Result<bool> {
+        let store = crate::graphql::get_store(ctx).await?;
+        let list = get_semi_model_list(&store)?;
+        let serialized_semi_model = bincode::DefaultOptions::new().serialize(&list)?;
+        let agent_manager = ctx.data::<BoxedAgentManager>()?;
+        agent_manager
+            .broadcast_semi_model_list(&serialized_semi_model)
+            .await?;
+        Ok(true)
+    }
+}
+type SemiModelValue = (SemiModel, DateTime<Utc>);
+
+#[derive(InputObject, Serialize, Deserialize)]
+#[allow(clippy::struct_field_names)]
+struct SemiModel {
+    model_type: i32,
+    model_name: String,
+    model_version: String,
+    model_description: String,
+    model_data: Vec<u8>,
+}
+
+#[derive(SimpleObject, Serialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct SemiModelInfo {
+    model_type: i32,
+    model_name: String,
+    model_version: String,
+    model_description: String,
+    model_data: Vec<u8>,
+    time: DateTime<Utc>,
+}
+
+impl SemiModelInfo {
+    fn new(semi_model: SemiModel, time: DateTime<Utc>) -> Self {
+        Self {
+            model_type: semi_model.model_type,
+            model_name: semi_model.model_name,
+            model_version: semi_model.model_version,
+            model_description: semi_model.model_description,
+            time,
+            model_data: semi_model.model_data,
+        }
+    }
+}
+
+impl FromKeyValue for SemiModelInfo {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self, anyhow::Error> {
+        let (semi_info, time) = bincode::deserialize::<SemiModelValue>(value)?;
+        Ok(SemiModelInfo::new(semi_info, time))
+    }
+}
+
+struct SemiModelInfoTotalCount;
+
+#[Object]
+impl SemiModelInfoTotalCount {
+    /// The total number of edges.
+    async fn total_count(&self, ctx: &Context<'_>) -> Result<usize> {
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.semi_models_map();
+        let count = map.iter_forward()?.count();
+        Ok(count)
+    }
+}
+
+/// Returns the semi supervised model list.
+///
+/// # Errors
+///
+/// Returns an error if semi supervised model database could not be retrieved.
+pub fn get_semi_model_list(db: &Store) -> Result<Vec<SemiModelInfo>> {
+    let map = db.semi_models_map();
+    let mut semi_model_list = vec![];
+    for (_, value) in map.iter_forward()? {
+        let (semi_info, time) = bincode::deserialize::<SemiModelValue>(&value)?;
+        semi_model_list.push(SemiModelInfo::new(semi_info, time));
+    }
+    Ok(semi_model_list)
+}
+
+async fn load(
+    ctx: &Context<'_>,
+    after: Option<String>,
+    before: Option<String>,
+    first: Option<usize>,
+    last: Option<usize>,
+) -> Result<Connection<String, SemiModelInfo, SemiModelInfoTotalCount, EmptyFields>> {
+    let store = crate::graphql::get_store(ctx).await?;
+    let map = store.semi_models_map();
+    super::load(&map, after, before, first, last, SemiModelInfoTotalCount)
+}

--- a/src/graphql/triage.rs
+++ b/src/graphql/triage.rs
@@ -19,6 +19,9 @@ pub(super) struct TriageResponseQuery;
 #[derive(Default)]
 pub(super) struct TriageResponseMutation;
 
+#[derive(Default)]
+pub(super) struct TriageMutation;
+
 pub(super) struct TriagePolicy {
     inner: database::TriagePolicy,
 }

--- a/src/graphql/triage/policy.rs
+++ b/src/graphql/triage/policy.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConfidenceInput, PacketAttrInput, ResponseInput, TiInput, TriagePolicy, TriagePolicyInput,
-    TriagePolicyMutation, TriagePolicyQuery,
+    ConfidenceInput, PacketAttrInput, ResponseInput, TiInput, TriageMutation, TriagePolicy,
+    TriagePolicyInput, TriagePolicyMutation, TriagePolicyQuery,
 };
 use super::{Role, RoleGuard};
 use async_graphql::{
@@ -8,7 +8,8 @@ use async_graphql::{
     Context, Object, Result, ID,
 };
 use bincode::Options;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
+use num_traits::ToPrimitive;
 use review_database::{
     self as database, Indexed, IndexedMap, IndexedMapIterator, IndexedMapUpdate,
 };
@@ -262,5 +263,29 @@ impl IndexedMapUpdate for TriagePolicyInput {
             return false;
         }
         true
+    }
+}
+
+#[Object]
+impl TriageMutation {
+    /// Inserts a new triage policy, returning the ID of the new triage.
+    #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
+        .or(RoleGuard::new(Role::SecurityAdministrator))")]
+    async fn insert_triage_result(
+        &self,
+        ctx: &Context<'_>,
+        timestamp: DateTime<Utc>,
+        event_kind: i32,
+        triage_result: String,
+    ) -> Result<String> {
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.triage_map();
+
+        let key = i128::from(timestamp.timestamp_nanos_opt().unwrap_or_default()) << 64
+            | event_kind.to_i128().expect("should not exceed i128::MAX") << 32;
+
+        let value = bincode::DefaultOptions::new().serialize(&triage_result)?;
+        map.put(&key.to_be_bytes(), &value)?;
+        Ok("done".to_string())
     }
 }


### PR DESCRIPTION
- Added graphql queries for triage and outliers.
- Added graphql queries for semi-supervised model.
- Added `agent_id` for filtering agent id to `EventListWithTriageFilterInput`.
- Added new fields to the sampling policy's enum Interval.