### PR TITLE
Remove unused arguments

### DIFF
--- a/src/graphql/cluster.rs
+++ b/src/graphql/cluster.rs
@@ -182,7 +182,7 @@ impl Cluster {
         Ok(map.get(u32::try_from(self.category)?)?.into())
     }
 
-    async fn events(&self, _ctx: &Context<'_>) -> Result<Vec<DateTime<Utc>>> {
+    async fn events(&self) -> Result<Vec<DateTime<Utc>>> {
         Ok(self
             .events
             .iter()

--- a/src/graphql/outlier.rs
+++ b/src/graphql/outlier.rs
@@ -436,7 +436,7 @@ impl Outlier {
         ID(self.id.to_string())
     }
 
-    async fn events(&self, _ctx: &Context<'_>) -> Result<Vec<DateTime<Utc>>> {
+    async fn events(&self) -> Result<Vec<DateTime<Utc>>> {
         Ok(self
             .events
             .iter()


### PR DESCRIPTION
This also fixes clippy warnings with Rust 1.76.