### PR TITLE
Add messaging functions to `AgentManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add unit tests to `customer_list` to check ordering of nodes and edges.
+- `AgentManager::get_resource_usage` method to retrieve the resource usage of a
+  host. It returns `graphql::ResourceUsage`.
 - `AgentManager::ping` method to measure the latency between the agent manager
   and a host.
 - `AgentManager::reboot` method to reboot a host.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add unit tests to `customer_list` to check ordering of nodes and edges.
+- `AgentManager::get_process_list` method to retrieve the list of processes
+  usage running on host. It returns a `Vec` of `graphql::Process`.
 - `AgentManager::get_resource_usage` method to retrieve the resource usage of a
   host. It returns `graphql::ResourceUsage`.
 - `AgentManager::ping` method to measure the latency between the agent manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add unit tests to `customer_list` to check ordering of nodes and edges.
+- `AgentManager::ping` method to measure the latency between the agent manager
+  and a host.
 - `AgentManager::reboot` method to reboot a host.
 
 ## [0.18.0] - 2024-02-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add unit tests to `customer_list` to check ordering of nodes and edges.
+- `AgentManager::reboot` method to reboot a host.
 
 ## [0.18.0] - 2024-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add unit tests to `customer_list` to check ordering of nodes and edges.
+- `AgentManager::broadcast_crusher_sampling_policy` method to broadcast the
+  sampling policy to the Crusher agents.
 - `AgentManager::get_process_list` method to retrieve the list of processes
   usage running on host. It returns a `Vec` of `graphql::Process`.
 - `AgentManager::get_resource_usage` method to retrieve the resource usage of a

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -94,6 +94,10 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
+    async fn reboot(&self, hostname: &str) -> Result<(), Error> {
+        bail!("Host {hostname} is unreachable")
+    }
+
     async fn update_traffic_filter_rules(
         &self,
         _key: &str,

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -8,6 +8,7 @@ use futures::{
 use ipnet::IpNet;
 use review_database::{migrate_data_dir, Database, Store};
 use review_web::{self as web, graphql::AgentManager, CertManager};
+use roxy::ResourceUsage;
 use serde::Deserialize;
 use std::{
     collections::HashMap,
@@ -92,6 +93,10 @@ impl AgentManager for Manager {
 
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, Error> {
         bail!("Not supported")
+    }
+
+    async fn get_resource_usage(&self, hostname: &str) -> Result<ResourceUsage, Error> {
+        bail!("Host {hostname} is unreachable")
     }
 
     async fn ping(&self, hostname: &str) -> Result<i64, Error> {

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -9,8 +9,7 @@ use ipnet::IpNet;
 use review_database::{migrate_data_dir, Database, Store};
 use review_web::{
     self as web,
-    graphql::AgentManager,
-    graphql::{Process, ResourceUsage},
+    graphql::{AgentManager, Process, ResourceUsage, SamplingPolicy},
     CertManager,
 };
 use serde::Deserialize;
@@ -97,6 +96,13 @@ impl AgentManager for Manager {
 
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, Error> {
         bail!("Not supported")
+    }
+
+    async fn broadcast_crusher_sampling_policy(
+        &self,
+        _policy: &[SamplingPolicy],
+    ) -> Result<(), Error> {
+        bail!("Crusher nodes are unreachable")
     }
 
     async fn get_process_list(&self, hostname: &str) -> Result<Vec<Process>, Error> {

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -94,6 +94,10 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
+    async fn ping(&self, hostname: &str) -> Result<i64, Error> {
+        bail!("Host {hostname} is unreachable")
+    }
+
     async fn reboot(&self, hostname: &str) -> Result<(), Error> {
         bail!("Host {hostname} is unreachable")
     }

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -7,8 +7,12 @@ use futures::{
 };
 use ipnet::IpNet;
 use review_database::{migrate_data_dir, Database, Store};
-use review_web::{self as web, graphql::AgentManager, CertManager};
-use roxy::ResourceUsage;
+use review_web::{
+    self as web,
+    graphql::AgentManager,
+    graphql::{Process, ResourceUsage},
+    CertManager,
+};
 use serde::Deserialize;
 use std::{
     collections::HashMap,
@@ -93,6 +97,10 @@ impl AgentManager for Manager {
 
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, Error> {
         bail!("Not supported")
+    }
+
+    async fn get_process_list(&self, hostname: &str) -> Result<Vec<Process>, Error> {
+        bail!("Host {hostname} is unreachable")
     }
 
     async fn get_resource_usage(&self, hostname: &str) -> Result<ResourceUsage, Error> {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -87,6 +87,15 @@ pub trait AgentManager: Send + Sync {
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
     async fn send_and_recv(&self, key: &str, msg: &[u8]) -> Result<Vec<u8>, anyhow::Error>;
+
+    /// Reboots the node with the given hostname.
+    async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error> {
+        // TODO: This body is only to avoid breaking changes. It should be
+        // removed when all the implementations are updated. See #144.
+        anyhow::bail!("not implemented")
+    }
+
+    /// Updates the traffic filter rules for the given host.
     async fn update_traffic_filter_rules(
         &self,
         host: &str,
@@ -675,6 +684,11 @@ impl AgentManager for MockAgentManager {
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
         unimplemented!()
     }
+
+    async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error> {
+        unimplemented!()
+    }
+
     async fn update_traffic_filter_rules(
         &self,
         _key: &str,

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -88,6 +88,14 @@ pub trait AgentManager: Send + Sync {
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
     async fn send_and_recv(&self, key: &str, msg: &[u8]) -> Result<Vec<u8>, anyhow::Error>;
 
+    /// Sends a ping message to the given host and waits for a response. Returns
+    /// the round-trip time in microseconds.
+    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error> {
+        // TODO: This body is only to avoid breaking changes. It should be
+        // removed when all the implementations are updated. See #144.
+        anyhow::bail!("not implemented")
+    }
+
     /// Reboots the node with the given hostname.
     async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error> {
         // TODO: This body is only to avoid breaking changes. It should be
@@ -682,6 +690,10 @@ impl AgentManager for MockAgentManager {
         Ok(HashMap::new())
     }
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+        unimplemented!()
+    }
+
+    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error> {
         unimplemented!()
     }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -53,6 +53,7 @@ use num_traits::ToPrimitive;
 use review_database::{
     self as database, types::FromKeyValue, Database, Direction, IterableMap, Role, Store,
 };
+pub use roxy::ResourceUsage;
 use std::{
     cmp,
     collections::HashMap,
@@ -87,6 +88,13 @@ pub trait AgentManager: Send + Sync {
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
     async fn send_and_recv(&self, key: &str, msg: &[u8]) -> Result<Vec<u8>, anyhow::Error>;
+
+    /// Returns the resource usage of the given host.
+    async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error> {
+        // TODO: This body is only to avoid breaking changes. It should be
+        // removed when all the implementations are updated. See #144.
+        anyhow::bail!("not implemented")
+    }
 
     /// Sends a ping message to the given host and waits for a response. Returns
     /// the round-trip time in microseconds.
@@ -690,6 +698,10 @@ impl AgentManager for MockAgentManager {
         Ok(HashMap::new())
     }
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+        unimplemented!()
+    }
+
+    async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error> {
         unimplemented!()
     }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -53,7 +53,7 @@ use num_traits::ToPrimitive;
 use review_database::{
     self as database, types::FromKeyValue, Database, Direction, IterableMap, Role, Store,
 };
-pub use roxy::ResourceUsage;
+pub use roxy::{Process, ResourceUsage};
 use std::{
     cmp,
     collections::HashMap,
@@ -88,6 +88,13 @@ pub trait AgentManager: Send + Sync {
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
     async fn send_and_recv(&self, key: &str, msg: &[u8]) -> Result<Vec<u8>, anyhow::Error>;
+
+    /// Returns the list of processes running on the given host.
+    async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error> {
+        // TODO: This body is only to avoid breaking changes. It should be
+        // removed when all the implementations are updated. See #144.
+        anyhow::bail!("not implemented")
+    }
 
     /// Returns the resource usage of the given host.
     async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error> {
@@ -698,6 +705,10 @@ impl AgentManager for MockAgentManager {
         Ok(HashMap::new())
     }
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+        unimplemented!()
+    }
+
+    async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error> {
         unimplemented!()
     }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -39,6 +39,10 @@ pub use self::block_network::get_block_networks;
 pub use self::cert::ParsedCertificate;
 pub use self::customer::get_customer_networks;
 pub use self::node::{get_customer_id_of_review_host, get_node_settings};
+pub use self::sampling::{
+    Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod,
+    Policy as SamplingPolicy,
+};
 pub use self::trusted_user_agent::get_trusted_user_agent_list;
 use async_graphql::connection::ConnectionNameType;
 use async_graphql::{
@@ -88,6 +92,15 @@ pub trait AgentManager: Send + Sync {
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>;
     async fn send_and_recv(&self, key: &str, msg: &[u8]) -> Result<Vec<u8>, anyhow::Error>;
+
+    async fn broadcast_crusher_sampling_policy(
+        &self,
+        _sampling_policies: &[SamplingPolicy],
+    ) -> Result<(), anyhow::Error> {
+        // TODO: This body is only to avoid breaking changes. It should be
+        // removed when all the implementations are updated. See #144.
+        anyhow::bail!("not implemented")
+    }
 
     /// Returns the list of processes running on the given host.
     async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error> {
@@ -705,6 +718,13 @@ impl AgentManager for MockAgentManager {
         Ok(HashMap::new())
     }
     async fn send_and_recv(&self, _key: &str, _msg: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+        unimplemented!()
+    }
+
+    async fn broadcast_crusher_sampling_policy(
+        &self,
+        _sampling_policies: &[SamplingPolicy],
+    ) -> Result<(), anyhow::Error> {
         unimplemented!()
     }
 

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -17,6 +17,8 @@ impl NodeControlMutation {
         if !review_hostname.is_empty() && review_hostname == hostname {
             roxy::reboot().map_or_else(|e| Err(e.to_string().into()), |_| Ok(hostname))
         } else {
+            // TODO: Refactor this code to use `AgentManager::reboot` after
+            // `review` implements it. See #144.
             let apps = agents.online_apps_by_host_id().await?;
             let Some(apps) = apps.get(&hostname) else {
                 return Err("unable to gather info of online agents".into());

--- a/src/graphql/node/process.rs
+++ b/src/graphql/node/process.rs
@@ -25,6 +25,8 @@ impl ProcessListQuery {
                 .map(Process::from)
                 .collect();
         } else {
+            // TODO: Refactor this code to use `AgentManager::process_list`
+            // after the `AgentManager` trait is implemented. See #144.
             let apps = agents.online_apps_by_host_id().await?;
             let Some(apps) = apps.get(&hostname) else {
                 return Err("unable to gather info of online agents".into());

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -57,6 +57,8 @@ async fn load(
     let mut usages: HashMap<String, ResourceUsage> = HashMap::new();
     let mut ping: HashMap<String, i64> = HashMap::new();
     for (_, key) in hostname_key {
+        // TODO: Refactor this code to use `AgentManager::resource_usage` after
+        // `review` implements it. See #144.
         if let Ok(response) = agents.send_and_recv(&key, &resource_msg).await {
             if let Ok(Ok((hostname, ru))) = bincode::DefaultOptions::new()
                 .deserialize::<Result<(String, ResourceUsage), &str>>(&response)

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -72,6 +72,8 @@ async fn load(
                     },
                 );
 
+                // TODO: Refactor this code to use `AgentManager::ping` after
+                // `review` implements it. See #144.
                 let start = Utc::now().timestamp_micros();
                 if let Ok(response) = agents.send_and_recv(&key, &ping_msg).await {
                     let end = Utc::now().timestamp_micros();

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -23,7 +23,7 @@ pub(super) struct SamplingPolicyMutation;
 
 #[derive(Clone, Copy, Eq, PartialEq, Enum, Deserialize, Serialize)]
 #[repr(u32)]
-pub(super) enum Interval {
+pub enum Interval {
     FiveMinutes = 0,
     TenMinutes = 1,
     FifteenMinutes = 2,
@@ -39,7 +39,7 @@ impl Default for Interval {
 
 #[derive(Clone, Copy, Eq, PartialEq, Enum, Deserialize, Serialize)]
 #[repr(u32)]
-pub(super) enum Period {
+pub enum Period {
     SixHours = 0,
     TwelveHours = 1,
     OneDay = 2,
@@ -53,7 +53,7 @@ impl Default for Period {
 
 #[derive(Clone, Copy, Eq, PartialEq, Enum, Deserialize, Serialize)]
 #[repr(u32)]
-pub(super) enum Kind {
+pub enum Kind {
     Conn = 0,
     Dns = 1,
     Http = 2,
@@ -209,16 +209,16 @@ async fn load(
 }
 
 #[derive(Serialize)]
-pub(super) struct Policy {
-    id: u32,
-    kind: Kind,
-    interval: Interval,
-    period: Period,
-    offset: i32,
-    src_ip: Option<IpAddr>,
-    dst_ip: Option<IpAddr>,
-    node: Option<String>,
-    column: Option<u32>,
+pub struct Policy {
+    pub id: u32,
+    pub kind: Kind,
+    pub interval: Interval,
+    pub period: Period,
+    pub offset: i32,
+    pub src_ip: Option<IpAddr>,
+    pub dst_ip: Option<IpAddr>,
+    pub node: Option<String>,
+    pub column: Option<u32>,
 }
 
 impl TryFrom<SamplingPolicy> for SamplingPolicyInput {
@@ -330,6 +330,9 @@ impl SamplingPolicyMutation {
         }
 
         if immutable {
+            // TODO: Refactor this code to use
+            // `AgentManager::broadcast_crusher_sampling_policy` after
+            // `review` implements it. See #144.
             let mut msg = bincode::serialize::<u32>(&RequestCode::SamplingPolicyList.into())?;
             let policies = load_immutable(ctx).await?;
             msg.extend(bincode::DefaultOptions::new().serialize(&policies)?);


### PR DESCRIPTION
* Pending: #150 (The CI fails because of the deprecated methods in chrono-0.4.35. The PR needs to be rebased after the issue has been resolved.)

The PR Adds the following methods to `AgentManager`:

- `AgentManager::broadcast_crusher_sampling_policy` method to broadcast the
  sampling policy to the Crusher agents.
- `AgentManager::get_process_list` method to retrieve the list of processes usage running on host. It returns a `Vec` of `graphql::Process`.
- `AgentManager::get_resource_usage` method to retrieve the resource usage of a host. It returns `graphql::ResourceUsage`.
- `AgentManager::ping` method to measure the latency between the agent manager and a host.
- `AgentManager::reboot` method to reboot a host.

This is a part of #144.