### PR TITLE
Use stricter time checking for JWT expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated the `ModelIndicator` GraphQL type. Added `name` field as the name of
   the model indicator.
 - Changed the return type of `indicatorList` GraphQL query to `[ModelIndicator!]!`.
+- GraphQL query `updateExpirationTime` returns an error if the expiration time
+  is less than one second.
+- `init_expiration_time` and `update_jwt_expires_in` take `u32` instead of `i64`
+  for the expiration time argument.
 
 ### Removed
 


### PR DESCRIPTION
This PR changes the type for JWT expiration time in GraphQL query from `i64` to `i32`, which is suggested in #37. Also, internally the expiration time is treated as `u32`, rather than `i64`, for better compile-time type checking.