### PR TITLE
Adapt to review-database's API change in review-database-0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.1" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "3803953" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "295f5b4" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.1" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "9a1b3e28" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "3803953" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.1" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "7765fc6a" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "2163c9c1" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.9.1" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "2163c9c1" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "9a1b3e28" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -7,10 +7,10 @@ use async_graphql::{
     Context, InputObject, Object, Result, ID,
 };
 use bincode::Options;
-use database::types::FromKeyValue;
-use review_database::{self as database, Indexable, Indexed, IndexedMapUpdate, IterableMap, Store};
+use database::Direction;
+use review_database::{self as database, Store};
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[derive(Default)]
@@ -61,13 +61,13 @@ impl BlockNetworkMutation {
         let map = db.block_network_map();
         let networks: database::HostNetworkGroup =
             networks.try_into().map_err(|_| "invalid network")?;
-        let value = BlockNetwork {
+        let value = review_database::BlockNetwork {
             id: u32::MAX,
             name,
             networks,
             description,
         };
-        let id = map.insert(value)?;
+        let id = map.put(value)?;
         Ok(ID(id.to_string()))
     }
 
@@ -87,7 +87,7 @@ impl BlockNetworkMutation {
         let mut removed = Vec::<String>::with_capacity(ids.len());
         for id in ids {
             let i = id.as_str().parse::<u32>().map_err(|_| "invalid ID")?;
-            let key = map.remove::<BlockNetwork>(i)?;
+            let key = map.remove(i)?;
 
             let name = match String::from_utf8(key) {
                 Ok(key) => key,
@@ -112,7 +112,9 @@ impl BlockNetworkMutation {
         let i = id.as_str().parse::<u32>().map_err(|_| "invalid ID")?;
 
         let db = super::get_store(ctx).await?;
-        let map = db.block_network_map();
+        let mut map = db.block_network_map();
+        let old: review_database::BlockNetworkUpdate = old.try_into()?;
+        let new: review_database::BlockNetworkUpdate = new.try_into()?;
         map.update(i, &old, &new)?;
         Ok(id)
     }
@@ -134,58 +136,31 @@ impl BlockNetworkMutation {
 
 #[derive(Deserialize, Serialize)]
 pub(super) struct BlockNetwork {
-    id: u32,
-    name: String,
-    networks: database::HostNetworkGroup,
-    description: String,
+    inner: review_database::BlockNetwork,
+}
+
+impl From<review_database::BlockNetwork> for BlockNetwork {
+    fn from(inner: review_database::BlockNetwork) -> Self {
+        Self { inner }
+    }
 }
 
 #[Object]
 impl BlockNetwork {
     async fn id(&self) -> ID {
-        ID(self.id.to_string())
+        ID(self.inner.id.to_string())
     }
 
     async fn name(&self) -> &str {
-        &self.name
+        &self.inner.name
     }
 
     async fn description(&self) -> &str {
-        &self.description
+        &self.inner.description
     }
 
     async fn networks(&self) -> HostNetworkGroup {
-        (&self.networks).into()
-    }
-}
-
-impl FromKeyValue for BlockNetwork {
-    fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
-        Ok(bincode::DefaultOptions::new().deserialize(value)?)
-    }
-}
-
-impl Indexable for BlockNetwork {
-    fn key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.name.as_bytes())
-    }
-
-    fn index(&self) -> u32 {
-        self.id
-    }
-
-    fn make_indexed_key(key: Cow<[u8]>, _index: u32) -> Cow<[u8]> {
-        key
-    }
-
-    fn value(&self) -> Vec<u8> {
-        bincode::DefaultOptions::new()
-            .serialize(self)
-            .expect("serializable")
-    }
-
-    fn set_index(&mut self, index: u32) {
-        self.id = index;
+        (&self.inner.networks).into()
     }
 }
 
@@ -196,48 +171,16 @@ struct BlockNetworkInput {
     description: Option<String>,
 }
 
-impl IndexedMapUpdate for BlockNetworkInput {
-    type Entry = BlockNetwork;
+impl TryFrom<BlockNetworkInput> for review_database::BlockNetworkUpdate {
+    type Error = anyhow::Error;
 
-    fn key(&self) -> Option<Cow<[u8]>> {
-        self.name.as_deref().map(str::as_bytes).map(Cow::Borrowed)
-    }
-
-    fn apply(&self, mut value: Self::Entry) -> Result<Self::Entry, anyhow::Error> {
-        if let Some(name) = self.name.as_deref() {
-            value.name.clear();
-            value.name.push_str(name);
-        }
-        if let Some(networks) = self.networks.as_ref() {
-            value.networks = networks.try_into()?;
-        }
-        if let Some(description) = self.description.as_deref() {
-            value.description.clear();
-            value.description.push_str(description);
-        }
-        Ok(value)
-    }
-
-    fn verify(&self, value: &Self::Entry) -> bool {
-        if let Some(v) = self.name.as_deref() {
-            if v != value.name {
-                return false;
-            }
-        }
-        if let Some(v) = self.networks.as_ref() {
-            let Ok(v) = database::HostNetworkGroup::try_from(v) else {
-                return false;
-            };
-            if v != value.networks {
-                return false;
-            }
-        }
-        if let Some(v) = self.description.as_deref() {
-            if v != value.description {
-                return false;
-            }
-        }
-        true
+    fn try_from(input: BlockNetworkInput) -> Result<Self, Self::Error> {
+        let networks = input.networks.map(TryInto::try_into).transpose()?;
+        Ok(Self {
+            name: input.name,
+            networks,
+            description: input.description,
+        })
     }
 }
 
@@ -261,7 +204,7 @@ async fn load(
 ) -> Result<Connection<String, BlockNetwork, BlockNetworkTotalCount, EmptyFields>> {
     let db = super::get_store(ctx).await?;
     let map = db.block_network_map();
-    super::load(&map, after, before, first, last, BlockNetworkTotalCount)
+    super::load_edges(&map, after, before, first, last, BlockNetworkTotalCount)
 }
 
 /// Returns the block network list.
@@ -270,14 +213,14 @@ async fn load(
 ///
 /// Returns an error if the block network database could not be retrieved.
 pub fn get_block_networks(db: &Store) -> Result<database::HostNetworkGroup> {
+    use review_database::Iterable;
+
     let map = db.block_network_map();
     let mut hosts = vec![];
     let mut networks = vec![];
     let mut ip_ranges = vec![];
-    for (_key, value) in map.iter_forward()? {
-        let block_network = bincode::DefaultOptions::new()
-            .deserialize::<BlockNetwork>(value.as_ref())
-            .map_err(|_| "invalid value in database")?;
+    for res in map.iter(Direction::Forward, None) {
+        let block_network = res?;
         hosts.extend(block_network.networks.hosts());
         networks.extend(block_network.networks.networks());
         ip_ranges.extend(block_network.networks.ip_ranges().to_vec());

--- a/src/graphql/category.rs
+++ b/src/graphql/category.rs
@@ -60,7 +60,9 @@ impl CategoryMutation {
         let db = ctx.data::<Arc<RwLock<Store>>>()?.read().await;
         let mut map = db.category_map();
         let id: u32 = id.as_str().parse()?;
-        let old = map.get(id)?;
+        let Some(old) = map.get_by_id(id)? else {
+            return Err("no such category".into());
+        };
         map.update(id, &old.name, &name)?;
         Ok(ID(id.to_string()))
     }

--- a/src/graphql/cluster.rs
+++ b/src/graphql/cluster.rs
@@ -182,7 +182,10 @@ impl Cluster {
     async fn category(&self, ctx: &Context<'_>) -> Result<Category> {
         let db = ctx.data::<Arc<RwLock<Store>>>()?.read().await;
         let map = db.category_map();
-        Ok(map.get(u32::try_from(self.category)?)?.into())
+        let Some(res) = map.get_by_id(u32::try_from(self.category)?)? else {
+            return Err("no such category".into());
+        };
+        Ok(res.into())
     }
 
     async fn events(&self) -> Result<Vec<DateTime<Utc>>> {
@@ -201,17 +204,19 @@ impl Cluster {
     async fn qualifier(&self, ctx: &Context<'_>) -> Result<Qualifier> {
         let db = ctx.data::<Arc<RwLock<Store>>>()?.read().await;
         let map = db.qualifier_map();
-        Ok(map
-            .get(u32::try_from(self.qualifier).expect("invalid id"))?
-            .into())
+        let Some(res) = map.get_by_id(u32::try_from(self.qualifier).expect("invalid id"))? else {
+            return Err("no such qualifier".into());
+        };
+        Ok(res.into())
     }
 
     async fn status(&self, ctx: &Context<'_>) -> Result<Status> {
         let db = ctx.data::<Arc<RwLock<Store>>>()?.read().await;
         let map = db.status_map();
-        Ok(map
-            .get(u32::try_from(self.status).expect("invalid id"))?
-            .into())
+        let Some(res) = map.get_by_id(u32::try_from(self.status).expect("invalid id"))? else {
+            return Err("no such status".into());
+        };
+        Ok(res.into())
     }
 }
 

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -879,7 +879,7 @@ fn convert_endpoint_input(
                 .as_str()
                 .parse::<u32>()
                 .context(format!("invalid ID: {}", id.as_str()))?;
-            let Some(network) = network_map.get(i)? else {
+            let Some(network) = network_map.get_by_id(i)? else {
                 bail!("no such network")
             };
             networks.push(Endpoint {

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -51,7 +51,7 @@ impl NetworkQuery {
 
         let store = crate::graphql::get_store(ctx).await?;
         let map = store.network_map();
-        let Some(inner) = map.get(i)? else {
+        let Some(inner) = map.get_by_id(i)? else {
             return Err("no such network".into());
         };
         Ok(Network { inner })

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -242,13 +242,6 @@ async fn load(
     super::load_edges(&map, after, before, first, last, NetworkTotalCount)
 }
 
-pub(super) async fn remove_tag(ctx: &Context<'_>, tag_id: u32) -> Result<()> {
-    let store = crate::graphql::get_store(ctx).await?;
-    let map = store.network_map();
-
-    Ok(map.remove_tag(tag_id)?)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::graphql::TestSchema;

--- a/src/graphql/qualifier.rs
+++ b/src/graphql/qualifier.rs
@@ -59,7 +59,9 @@ impl QualifierMutation {
         let db = ctx.data::<Arc<RwLock<Store>>>()?.read().await;
         let mut map = db.qualifier_map();
         let id: u32 = id.as_str().parse()?;
-        let old = map.get(id)?;
+        let Some(old) = map.get_by_id(id)? else {
+            return Err("no such qualifier".into());
+        };
         map.update(id, &old.description, &description)?;
         Ok(ID(id.to_string()))
     }

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -59,7 +59,9 @@ impl StatusMutation {
         let db = ctx.data::<Arc<RwLock<Store>>>()?.read().await;
         let mut map = db.status_map();
         let id: u32 = id.as_str().parse()?;
-        let old = map.get(id)?;
+        let Some(old) = map.get_by_id(id)? else {
+            return Err("no such status".into());
+        };
         map.update(id, &old.description, &description)?;
         Ok(ID(id.to_string()))
     }


### PR DESCRIPTION
* Pending: #151

- `Store::network_tag_set` now returns `TagSet`, rather than `IndexedSet`.
- Use `IndexedTable::get_by_id`, a routine replacing multiple, near-identical methods.