### PR TITLE
Use `AgentManager`'s newly-added methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   This enhancement ensures better consistency and adherence to best practices in
   handling pagination requests.
 
+### Removed
+
+- `AgentManager` no longer provides shared behavior for the following methods:
+  - `broadcast_crusher_sampling_policy`
+  - `get_process_list`
+  - `get_resource_usage`
+  - `ping`
+  - `reboot`
+  The implementor of `AgentManager` is now responsible for providing the
+  behavior for these methods.
+
 ## [0.19.0] - 2024-03-18
 
 ### Changed
@@ -482,6 +493,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - An initial version.
 
+[Unreleased]: https://github.com/aicers/review-web/compare/0.19.0...main
 [0.19.0]: https://github.com/aicers/review-web/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/aicers/review-web/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/aicers/review-web/compare/0.16.0...0.17.0

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -109,51 +109,27 @@ pub trait AgentManager: Send + Sync {
     async fn broadcast_crusher_sampling_policy(
         &self,
         _sampling_policies: &[SamplingPolicy],
-    ) -> Result<(), anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    ) -> Result<(), anyhow::Error>;
 
     /// Returns the configuration of the given agent.
     async fn get_config(
         &self,
         _hostname: &str,
         _agent_id: &str,
-    ) -> Result<oinq::Config, anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    ) -> Result<oinq::Config, anyhow::Error>;
 
     /// Returns the list of processes running on the given host.
-    async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error>;
 
     /// Returns the resource usage of the given host.
-    async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error>;
 
     /// Sends a ping message to the given host and waits for a response. Returns
     /// the round-trip time in microseconds.
-    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error>;
 
     /// Reboots the node with the given hostname.
-    async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error>;
 
     /// Sets the configuration of the given agent.
     async fn set_config(
@@ -161,11 +137,7 @@ pub trait AgentManager: Send + Sync {
         _hostname: &str,
         _agent_id: &str,
         _config: &oinq::Config,
-    ) -> Result<(), anyhow::Error> {
-        // TODO: This body is only to avoid breaking changes. It should be
-        // removed when all the implementations are updated. See #144.
-        anyhow::bail!("not implemented")
-    }
+    ) -> Result<(), anyhow::Error>;
 
     /// Updates the traffic filter rules for the given host.
     async fn update_traffic_filter_rules(

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -570,7 +570,7 @@ mod tests {
     use serde_json::json;
     use tokio::sync::mpsc::{self, Sender};
 
-    use crate::graphql::{AgentManager, BoxedAgentManager, TestSchema};
+    use crate::graphql::{AgentManager, BoxedAgentManager, SamplingPolicy, TestSchema};
 
     #[tokio::test]
     async fn test_node_apply() {
@@ -1137,6 +1137,54 @@ mod tests {
             self.insert_result(key).await;
             Ok(vec![])
         }
+
+        async fn broadcast_crusher_sampling_policy(
+            &self,
+            _sampling_policies: &[SamplingPolicy],
+        ) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+
+        /// Returns the configuration of the given agent.
+        async fn get_config(
+            &self,
+            hostname: &str,
+            _agent_id: &str,
+        ) -> Result<oinq::Config, anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
+        async fn get_process_list(
+            &self,
+            hostname: &str,
+        ) -> Result<Vec<roxy::Process>, anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
+        async fn get_resource_usage(
+            &self,
+            hostname: &str,
+        ) -> Result<roxy::ResourceUsage, anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
+        async fn ping(&self, hostname: &str) -> Result<i64, anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
+        async fn reboot(&self, hostname: &str) -> Result<(), anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
+        async fn set_config(
+            &self,
+            hostname: &str,
+            _agent_id: &str,
+            _config: &oinq::Config,
+        ) -> Result<(), anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
         async fn update_traffic_filter_rules(
             &self,
             _key: &str,

--- a/src/graphql/node/process.rs
+++ b/src/graphql/node/process.rs
@@ -3,9 +3,6 @@ use super::{
     Process, ProcessListQuery,
 };
 use async_graphql::{Context, Object, Result};
-use bincode::Options;
-use oinq::RequestCode;
-use roxy::Process as RoxyProcess;
 
 #[Object]
 impl ProcessListQuery {
@@ -16,60 +13,11 @@ impl ProcessListQuery {
         let agents = ctx.data::<BoxedAgentManager>()?;
         let review_hostname = roxy::hostname();
 
-        let process_list: Vec<Process>;
-
-        if !review_hostname.is_empty() && review_hostname == hostname {
-            process_list = roxy::process_list()
-                .await
-                .into_iter()
-                .map(Process::from)
-                .collect();
+        let processes = if !review_hostname.is_empty() && review_hostname == hostname {
+            roxy::process_list().await
         } else {
-            // TODO: Refactor this code to use `AgentManager::process_list`
-            // after the `AgentManager` trait is implemented. See #144.
-            let apps = agents.online_apps_by_host_id().await?;
-            let Some(apps) = apps.get(&hostname) else {
-                return Err("unable to gather info of online agents".into());
-            };
-
-            // The priority of applications (`Hog`, followed by `Crusher` and
-            // then `Piglet`) is determined based on their roles and
-            // capabilities in the system.
-            //
-            // 1. `Hog` has the highest priority because it can act as a dummy
-            //    agent to monitor servers where our software isn't installed.
-            //    This is essential for comprehensive system monitoring.
-            // 2. `Crusher` and `Piglet` are preferred for process list
-            //    collection because they maintain a continuous connection to
-            //    REview.
-            // 3. `REconverge` is not suited for process list collection due to
-            //    its intermittent connection.
-            // 4. The order of Hog, Crusher, and Piglet also considers the load
-            //    each program can handle.
-            let priority_app = apps
-                .iter()
-                .find(|(_, app_name)| app_name == "hog")
-                .or_else(|| apps.iter().find(|(_, app_name)| app_name == "piglet"))
-                .or_else(|| apps.iter().find(|(_, app_name)| app_name == "crusher"));
-
-            let Some((key, _)) = priority_app else {
-                return Err("unable to get process list".into());
-            };
-
-            let process_list_code: u32 = RequestCode::ProcessList.into();
-            let process_list_msg = bincode::serialize(&process_list_code)?;
-
-            let response = agents.send_and_recv(key, &process_list_msg).await?;
-            if let Ok(Ok(list)) = bincode::DefaultOptions::new()
-                .deserialize::<Result<Vec<RoxyProcess>, &str>>(&response)
-            {
-                process_list = list.into_iter().map(Process::from).collect();
-            } else {
-                // Since the node turns off, deserialization fails.
-                return Err("unable to deserialize process list".into());
-            };
-        }
-
-        Ok(process_list)
+            agents.get_process_list(&hostname).await?
+        };
+        Ok(processes.into_iter().map(Process::from).collect())
     }
 }


### PR DESCRIPTION
This PR replaces the protocol-level implementations of agent communication with corresponding methods in `AgentManager` for the following methods:

- `broadcast_crusher_sampling_policy`
- `get_process_list`
- `get_resource_usage`
- `ping`
- `reboot`

This is a part of #144.