### PR TITLE
Add `AgentManager::halt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `AgentManager::halt` method to shut down a host.
+
 ### Changed
 
 - GraphQL queries `accountList`, `allowNetworkList`, `blockNetworkList`, `categories`,

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -117,6 +117,10 @@ impl AgentManager for Manager {
         bail!("Host {hostname} is unreachable")
     }
 
+    async fn halt(&self, hostname: &str) -> Result<(), Error> {
+        bail!("Host {hostname} is unreachable")
+    }
+
     async fn ping(&self, hostname: &str) -> Result<i64, Error> {
         bail!("Host {hostname} is unreachable")
     }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -124,6 +124,9 @@ pub trait AgentManager: Send + Sync {
     /// Returns the resource usage of the given host.
     async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error>;
 
+    /// Halts the node with the given hostname.
+    async fn halt(&self, _hostname: &str) -> Result<(), anyhow::Error>;
+
     /// Sends a ping message to the given host and waits for a response. Returns
     /// the round-trip time in microseconds.
     async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error>;
@@ -772,6 +775,10 @@ impl AgentManager for MockAgentManager {
     }
 
     async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error> {
+        unimplemented!()
+    }
+
+    async fn halt(&self, _hostname: &str) -> Result<(), anyhow::Error> {
         unimplemented!()
     }
 

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -46,8 +46,8 @@ impl NodeControlMutation {
         if !review_hostname.is_empty() && review_hostname == hostname {
             Err("cannot shutdown. review shutdown is not allowed".into())
         } else {
-            // TODO: Refactor this code to use `AgentManager::shutdown` after
-            // `review` implements it.
+            // TODO: Refactor this code to use `AgentManager::halt` after
+            // `review` implements it. See #144.
             let apps = agents.online_apps_by_host_id().await?;
             let Some(apps) = apps.get(&hostname) else {
                 return Err("unable to gather info of online agents".into());
@@ -1144,6 +1144,10 @@ mod tests {
             &self,
             hostname: &str,
         ) -> Result<roxy::ResourceUsage, anyhow::Error> {
+            anyhow::bail!("{hostname} is unreachable")
+        }
+
+        async fn halt(&self, hostname: &str) -> Result<(), anyhow::Error> {
             anyhow::bail!("{hostname} is unreachable")
         }
 


### PR DESCRIPTION
This will be used by GraphQL API `nodeShutdown`.

A part of #144.