### PR TITLE
Refactor dependencies to use review-protocol crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ ipnet = { version = "2", features = ["serde"] }
 jsonwebtoken = "9"
 lazy_static = "1"
 num-traits = "0.2"
-oinq = { git = "https://github.com/petabi/oinq.git", tag = "0.10.0" }
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
 review-database = { git = "https://github.com/petabi/review-database.git", rev = "e330180d" }
+review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.1.2" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -105,7 +105,11 @@ impl AgentManager for Manager {
         bail!("Crusher nodes are unreachable")
     }
 
-    async fn get_config(&self, hostname: &str, agent_id: &str) -> Result<oinq::Config, Error> {
+    async fn get_config(
+        &self,
+        hostname: &str,
+        agent_id: &str,
+    ) -> Result<review_protocol::types::Config, Error> {
         bail!("Agent {agent_id}@{hostname} is unreachable")
     }
 
@@ -133,7 +137,7 @@ impl AgentManager for Manager {
         &self,
         hostname: &str,
         agent_id: &str,
-        _config: &oinq::Config,
+        _config: &review_protocol::types::Config,
     ) -> Result<(), Error> {
         bail!("Agent {agent_id}@{hostname} is unreachable")
     }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -116,7 +116,7 @@ pub trait AgentManager: Send + Sync {
         &self,
         _hostname: &str,
         _agent_id: &str,
-    ) -> Result<oinq::Config, anyhow::Error>;
+    ) -> Result<review_protocol::types::Config, anyhow::Error>;
 
     /// Returns the list of processes running on the given host.
     async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error>;
@@ -139,7 +139,7 @@ pub trait AgentManager: Send + Sync {
         &self,
         _hostname: &str,
         _agent_id: &str,
-        _config: &oinq::Config,
+        _config: &review_protocol::types::Config,
     ) -> Result<(), anyhow::Error>;
 
     /// Updates the traffic filter rules for the given host.
@@ -786,7 +786,7 @@ impl AgentManager for MockAgentManager {
         &self,
         _hostname: &str,
         _agent_id: &str,
-    ) -> Result<oinq::Config, anyhow::Error> {
+    ) -> Result<review_protocol::types::Config, anyhow::Error> {
         unimplemented!()
     }
 
@@ -814,7 +814,7 @@ impl AgentManager for MockAgentManager {
         &self,
         _hostname: &str,
         _agent_id: &str,
-        _config: &oinq::Config,
+        _config: &review_protocol::types::Config,
     ) -> Result<(), anyhow::Error> {
         unimplemented!()
     }

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -317,8 +317,8 @@ impl HogConfig {
     }
 }
 
-impl From<oinq::request::HogConfig> for HogConfig {
-    fn from(value: oinq::request::HogConfig) -> Self {
+impl From<review_protocol::types::HogConfig> for HogConfig {
+    fn from(value: review_protocol::types::HogConfig) -> Self {
         Self {
             review_ip: value.review_address.ip(),
             review_port: value.review_address.port(),
@@ -354,8 +354,8 @@ impl PigletConfig {
     }
 }
 
-impl From<oinq::request::PigletConfig> for PigletConfig {
-    fn from(value: oinq::request::PigletConfig) -> Self {
+impl From<review_protocol::types::PigletConfig> for PigletConfig {
+    fn from(value: review_protocol::types::PigletConfig) -> Self {
         Self {
             review_ip: value.review_address.ip(),
             review_port: value.review_address.port(),
@@ -389,8 +389,8 @@ impl ReconvergeConfig {
     }
 }
 
-impl From<oinq::request::ReconvergeConfig> for ReconvergeConfig {
-    fn from(value: oinq::request::ReconvergeConfig) -> Self {
+impl From<review_protocol::types::ReconvergeConfig> for ReconvergeConfig {
+    fn from(value: review_protocol::types::ReconvergeConfig) -> Self {
         Self {
             review_ip: value.review_address.ip(),
             review_port: value.review_address.port(),

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::graphql::{customer::broadcast_customer_networks, get_customer_networks};
 use async_graphql::{Context, Object, Result, SimpleObject, ID};
-use oinq::request::{HogConfig, PigletConfig, ReconvergeConfig};
 use review_database::{Node, NodeSetting};
 use std::net::{IpAddr, SocketAddr};
 use tracing::{error, info};
@@ -144,7 +143,7 @@ async fn send_set_config_request(
     agents: &BoxedAgentManager,
     hostname: &str,
     module_name: &str,
-    config: &oinq::Config,
+    config: &review_protocol::types::Config,
 ) -> anyhow::Result<bool> {
     for _ in 0..MAX_SET_CONFIG_TRY_COUNT {
         let set_config_response = agents.set_config(hostname, module_name, config).await;
@@ -159,7 +158,7 @@ async fn send_set_config_request(
 
 fn target_app_configs(
     settings_draft: &NodeSetting,
-) -> anyhow::Result<Vec<(ModuleName, oinq::Config)>> {
+) -> anyhow::Result<Vec<(ModuleName, review_protocol::types::Config)>> {
     let mut configurations = Vec::new();
 
     if settings_draft.piglet {
@@ -180,7 +179,9 @@ fn target_app_configs(
     Ok(configurations)
 }
 
-fn build_piglet_config(settings_draft: &NodeSetting) -> anyhow::Result<oinq::Config> {
+fn build_piglet_config(
+    settings_draft: &NodeSetting,
+) -> anyhow::Result<review_protocol::types::Config> {
     let review_address = build_socket_address(
         settings_draft.piglet_review_ip,
         settings_draft.piglet_review_port,
@@ -194,15 +195,19 @@ fn build_piglet_config(settings_draft: &NodeSetting) -> anyhow::Result<oinq::Con
     let log_options = build_log_options(settings_draft);
     let http_file_types = build_http_file_types(settings_draft);
 
-    Ok(oinq::Config::Piglet(PigletConfig {
-        review_address,
-        giganto_address,
-        log_options,
-        http_file_types,
-    }))
+    Ok(review_protocol::types::Config::Piglet(
+        review_protocol::types::PigletConfig {
+            review_address,
+            giganto_address,
+            log_options,
+            http_file_types,
+        },
+    ))
 }
 
-fn build_hog_config(settings_draft: &NodeSetting) -> anyhow::Result<oinq::Config> {
+fn build_hog_config(
+    settings_draft: &NodeSetting,
+) -> anyhow::Result<review_protocol::types::Config> {
     let review_address =
         build_socket_address(settings_draft.hog_review_ip, settings_draft.hog_review_port)
             .ok_or_else(|| anyhow::anyhow!("hog review address is not set"))?;
@@ -213,12 +218,14 @@ fn build_hog_config(settings_draft: &NodeSetting) -> anyhow::Result<oinq::Config
     let active_protocols = build_active_protocols(settings_draft);
     let active_sources = build_active_sources(settings_draft);
 
-    Ok(oinq::Config::Hog(HogConfig {
-        review_address,
-        giganto_address,
-        active_protocols,
-        active_sources,
-    }))
+    Ok(review_protocol::types::Config::Hog(
+        review_protocol::types::HogConfig {
+            review_address,
+            giganto_address,
+            active_protocols,
+            active_sources,
+        },
+    ))
 }
 
 fn build_log_options(settings_draft: &NodeSetting) -> Option<Vec<String>> {
@@ -302,7 +309,9 @@ fn build_active_sources(settings_draft: &NodeSetting) -> Option<Vec<String>> {
     }
 }
 
-fn build_reconverge_config(settings_draft: &NodeSetting) -> anyhow::Result<oinq::Config> {
+fn build_reconverge_config(
+    settings_draft: &NodeSetting,
+) -> anyhow::Result<review_protocol::types::Config> {
     let review_address = build_socket_address(
         settings_draft.reconverge_review_ip,
         settings_draft.reconverge_review_port,
@@ -314,10 +323,12 @@ fn build_reconverge_config(settings_draft: &NodeSetting) -> anyhow::Result<oinq:
         settings_draft.reconverge_giganto_port,
     );
 
-    Ok(oinq::Config::Reconverge(ReconvergeConfig {
-        review_address,
-        giganto_address,
-    }))
+    Ok(review_protocol::types::Config::Reconverge(
+        review_protocol::types::ReconvergeConfig {
+            review_address,
+            giganto_address,
+        },
+    ))
 }
 
 fn build_socket_address(ip: Option<IpAddr>, port: Option<u16>) -> Option<SocketAddr> {
@@ -1073,7 +1084,7 @@ mod tests {
             &self,
             hostname: &str,
             _agent_id: &str,
-        ) -> Result<oinq::Config, anyhow::Error> {
+        ) -> Result<review_protocol::types::Config, anyhow::Error> {
             anyhow::bail!("{hostname} is unreachable")
         }
 
@@ -1107,7 +1118,7 @@ mod tests {
             &self,
             hostname: &str,
             agent_id: &str,
-            _config: &oinq::Config,
+            _config: &review_protocol::types::Config,
         ) -> Result<(), anyhow::Error> {
             self.insert_result(format!("{agent_id}@{hostname}").as_str())
                 .await;

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -115,7 +115,9 @@ async fn load(
                             .await
                             .ok()
                             .and_then(|cfg| match cfg {
-                                oinq::Config::Piglet(piglet_config) => Some(piglet_config.into()),
+                                review_protocol::types::Config::Piglet(piglet_config) => {
+                                    Some(piglet_config.into())
+                                }
                                 _ => None,
                             })
                     } else {
@@ -127,7 +129,7 @@ async fn load(
                             .await
                             .ok()
                             .and_then(|cfg| match cfg {
-                                oinq::Config::Reconverge(reconverge_config) => {
+                                review_protocol::types::Config::Reconverge(reconverge_config) => {
                                     Some(reconverge_config.into())
                                 }
                                 _ => None,
@@ -141,7 +143,9 @@ async fn load(
                             .await
                             .ok()
                             .and_then(|cfg| match cfg {
-                                oinq::Config::Hog(hog_config) => Some(hog_config.into()),
+                                review_protocol::types::Config::Hog(hog_config) => {
+                                    Some(hog_config.into())
+                                }
                                 _ => None,
                             })
                     } else {


### PR DESCRIPTION
This pull request addresses the issue in `oinq` regarding its structure and modularity, as described in petabi/oinq#60. Currently, `oinq` serves as a comprehensive package for implementing the communication protocol within the REview ecosystem, relying on QUIC for efficient and secure communication. However, to promote code reuse and collaboration among projects utilizing QUIC, it's proposed to refactor `oinq` into two separate crates:

1. **`oinq`**: This crate will focus solely on low-level network communication, such as sending and receiving messages and streams.
2. **`review-protocol`**: Built on top of `oinq`, this crate will implement the application-specific protocol for the REview ecosystem.

This pull request implements the proposed changes by replacing direct dependencies on `oinq` within review-web with dependencies on `review-protocol` where necessary. Specifically, the changes include modifying import paths and types to align with the new crate structure.

## Changes Made

- Updated import paths to use types and functions from `review_protocol` instead of `oinq`.
- Replaced direct dependencies on `oinq` with dependencies on `review-protocol`.

**Note**: There's no functional change caused by this PR. The functionality remains intact, and the modifications solely pertain to dependency management and code organization.
