### PR TITLE
Update review-database to 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   GraphQL API.
 - Use `halt` of `AgentManager`, instead of `send_and_recv` in `nodeShutdown`
   GraphQL API.
+- Updated review-database to 0.27.0.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "e330180d" }
+review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.27.0" }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.1.2" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -931,7 +931,7 @@ fn convert_sensors(
             bail!("no such sensor")
         };
 
-        if let Some(node_settings) = node.setting {
+        if let Some(node_settings) = node.settings {
             if !node_settings.hostname.is_empty() {
                 converted_sensors.push(node_settings.hostname.clone());
             }

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -166,8 +166,8 @@ pub struct NodeSettings {
     sensor_list: HashMap<String, bool>,
 }
 
-impl From<review_database::NodeSetting> for NodeSettings {
-    fn from(input: review_database::NodeSetting) -> Self {
+impl From<review_database::NodeSettings> for NodeSettings {
+    fn from(input: review_database::NodeSettings) -> Self {
         Self {
             customer_id: input.customer_id,
             description: input.description.clone(),
@@ -233,8 +233,8 @@ impl From<review_database::Node> for Node {
             id: input.id,
             name: input.name,
             name_draft: input.name_draft,
-            settings: input.setting.map(Into::into),
-            settings_draft: input.setting_draft.map(Into::into),
+            settings: input.settings.map(Into::into),
+            settings_draft: input.settings_draft.map(Into::into),
             creation_time: input.creation_time,
         }
     }

--- a/src/graphql/node/input.rs
+++ b/src/graphql/node/input.rs
@@ -56,7 +56,7 @@ pub struct NodeSettingsInput {
     pub sensor_list: HashMap<String, bool>,
 }
 
-impl TryFrom<NodeSettingsInput> for review_database::NodeSetting {
+impl TryFrom<NodeSettingsInput> for review_database::NodeSettings {
     type Error = anyhow::Error;
 
     fn try_from(input: NodeSettingsInput) -> Result<Self, Self::Error> {
@@ -127,8 +127,8 @@ impl TryFrom<NodeInput> for review_database::NodeUpdate {
         Ok(Self {
             name: Some(input.name),
             name_draft: input.name_draft,
-            setting: input.settings.map(TryInto::try_into).transpose()?,
-            setting_draft: input.settings_draft.map(TryInto::try_into).transpose()?,
+            settings: input.settings.map(TryInto::try_into).transpose()?,
+            settings_draft: input.settings_draft.map(TryInto::try_into).transpose()?,
         })
     }
 }
@@ -144,7 +144,7 @@ pub(super) fn create_draft_update(
     old: &NodeInput,
     new: NodeDraftInput,
 ) -> Result<review_database::NodeUpdate> {
-    let (name_draft, setting_draft) = if let Some(draft) = new.settings_draft {
+    let (name_draft, settings_draft) = if let Some(draft) = new.settings_draft {
         (new.name_draft, Some(draft.try_into()?))
     } else {
         (None, None)
@@ -152,7 +152,7 @@ pub(super) fn create_draft_update(
     Ok(review_database::NodeUpdate {
         name: Some(old.name.clone()),
         name_draft,
-        setting: old.settings.clone().map(TryInto::try_into).transpose()?,
-        setting_draft,
+        settings: old.settings.clone().map(TryInto::try_into).transpose()?,
+        settings_draft,
     })
 }


### PR DESCRIPTION
closes #196 

Updating review-database to 0.27.0 requires changing names of structs, fields, and variables, that are related to `Node`.