### PR TITLE
Remove unused function from `AgentManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `reboot`
   The implementor of `AgentManager` is now responsible for providing the
   behavior for these methods.
-- `AgentManager::send_and_recv` has been removed because it exposed the
-  underlying communication mechanism to the caller. The caller should now use
-  the specific methods provided by `AgentManager` to interact with the agent.
+- `AgentManager::send_and_recv` and `broadcast_to_crusher` has been removed
+  because they exposed the underlying communication mechanism to the caller. The
+  caller should now use the specific methods provided by `AgentManager` to
+  interact with the agent.
 
 ## [0.19.0] - 2024-03-18
 

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -64,10 +64,6 @@ struct Manager;
 
 #[async_trait]
 impl AgentManager for Manager {
-    async fn broadcast_to_crusher(&self, _msg: &[u8]) -> Result<(), Error> {
-        bail!("Not supported")
-    }
-
     async fn broadcast_trusted_domains(&self) -> Result<(), Error> {
         bail!("Not supported")
     }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -74,10 +74,6 @@ pub(super) type Schema = async_graphql::Schema<Query, Mutation, Subscription>;
 
 #[async_trait]
 pub trait AgentManager: Send + Sync {
-    async fn broadcast_to_crusher(&self, _message: &[u8]) -> Result<(), anyhow::Error> {
-        self.default()
-    }
-
     async fn broadcast_trusted_domains(&self) -> Result<(), anyhow::Error> {
         self.default()
     }
@@ -734,9 +730,6 @@ struct MockAgentManager {}
 #[cfg(test)]
 #[async_trait]
 impl AgentManager for MockAgentManager {
-    async fn broadcast_to_crusher(&self, _msg: &[u8]) -> Result<(), anyhow::Error> {
-        unimplemented!()
-    }
     async fn broadcast_trusted_domains(&self) -> Result<(), anyhow::Error> {
         unimplemented!()
     }

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -1029,9 +1029,6 @@ mod tests {
 
     #[async_trait]
     impl AgentManager for MockAgentManager {
-        async fn broadcast_to_crusher(&self, _msg: &[u8]) -> Result<(), anyhow::Error> {
-            anyhow::bail!("not expected to be called")
-        }
         async fn broadcast_trusted_domains(&self) -> Result<(), anyhow::Error> {
             anyhow::bail!("not expected to be called")
         }


### PR DESCRIPTION
* Pending: #201

`broadcast_to_crusher` is no longer used and shouldn't be used in the future, since it assumes review-web knows the protocol between REview and agents. See #144 for background.