### PR TITLE
Update review-protocol to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
 review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.27.0" }
-review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.1.2" }
+review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.2.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"
 rustls-native-certs = "0.6"


### PR DESCRIPTION
This reduces the dependency tree of review-web by eliminating the large indirect dependency (through review-protocol) on quinn.