### PR TITLE
Configure pq-sys for GitHub Actions on macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+    - name: Set PQ_LIB_DIR
+      if: runner.os == 'macOS'
+      run: echo "PQ_LIB_DIR=$(brew --prefix libpq)/lib" >> $GITHUB_ENV
     - name: Build
       run: cargo build --examples --verbose
     - name: Run tests


### PR DESCRIPTION
This PR addresses an issue where linking with the pq-sys crate was failing on macOS 14 due to an inability to locate the libpq library. The issue was identified following a query from @sehkone, who asked about persistent CI errors related to this problem. The root cause was Homebrew's change in its default installation directory, shifting from `/usr/local` to `/opt/homebrew`. The pq-sys crate was still attempting to access the library in the old location. To resolve this, we have explicitly passed the correct library directory to pq-sys using an environment variable, ensuring proper linkage.

While this query was raised via a private email, we encourage the use of GitHub issues for such inquiries in the future. This allows for more transparent, collaborative tracking and discussion of the problems and potential solutions.
