### PR TITLE
Change admin account to read `REVIEW_ADMIN` env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## Fixed
+### Changed
+
+- Change admin account to read environment variable `REVIEW_ADMIN` from hardcoded
+  value.
+
+### Fixed
 
 - Correct the release date of `0.20.0` to `2024-04-25`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ vinum = { git = "https://github.com/vinesystems/vinum.git", tag = "1.0.3" }
 assert-json-diff = "2.0.2"
 config = { version = "0.13", features = ["toml"], default-features = false }
 futures = "0.3"
+serial_test = "3.1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "signal", "sync"] }
 tracing-appender = "0.2"


### PR DESCRIPTION
- Refactored initialization code in `set_initial_admin_password` to check for the presence of the `REVIEW_ADMIN` environment variable `admin:password`. If available, parses the variable to obtain the username and password for the initial administrator account. Returns an error if the REVIEW_ADMIN variable is invalid or unavailable. This change eliminates hardcoded credentials, improving security and flexibility.

Close: #38