### PR TITLE
Update `outlier` interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.11", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.27.1" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "912c247" }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.2.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.21"

--- a/src/graphql/account.rs
+++ b/src/graphql/account.rs
@@ -1,6 +1,5 @@
 use super::RoleGuard;
 use crate::auth::{create_token, decode_token, insert_token, revoke_token, update_jwt_expires_in};
-use crate::graphql::validate_and_process_pagination_params;
 use anyhow::anyhow;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
@@ -65,9 +64,6 @@ impl AccountQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Account, AccountTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -2,7 +2,6 @@ use super::{
     customer::{HostNetworkGroup, HostNetworkGroupInput},
     BoxedAgentManager, Role, RoleGuard,
 };
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
@@ -30,9 +29,6 @@ impl AllowNetworkQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, AllowNetwork, AllowNetworkTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -2,7 +2,6 @@ use super::{
     customer::{HostNetworkGroup, HostNetworkGroupInput},
     BoxedAgentManager, Role, RoleGuard,
 };
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
@@ -32,9 +31,6 @@ impl BlockNetworkQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, BlockNetwork, BlockNetworkTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/category.rs
+++ b/src/graphql/category.rs
@@ -1,5 +1,4 @@
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -28,9 +27,6 @@ impl CategoryQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Category, CategoryTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/cluster.rs
+++ b/src/graphql/cluster.rs
@@ -9,7 +9,6 @@ use super::{
     status::Status,
     Role, RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
 };
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     types::ID,
@@ -51,8 +50,6 @@ impl ClusterQuery {
         let detectors = try_id_args_into_ints(detectors)?;
         let qualifiers = try_id_args_into_ints(qualifiers)?;
         let statuses = try_id_args_into_ints(statuses)?;
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
 
         query(
             after,

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -1,5 +1,4 @@
 use super::{get_customer_id_of_review_host, BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use anyhow::Context as AnyhowContext;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
@@ -28,9 +27,6 @@ impl CustomerQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Customer, CustomerTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/data_source.rs
+++ b/src/graphql/data_source.rs
@@ -1,5 +1,4 @@
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -25,9 +24,6 @@ impl DataSourceQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, DataSource, DataSourceTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -36,7 +36,6 @@ use super::{
     network::Network,
     Role, RoleGuard,
 };
-use crate::graphql::validate_and_process_pagination_params;
 use anyhow::{anyhow, bail, Context as AnyhowContext};
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
@@ -432,9 +431,6 @@ impl EventQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Event, EventTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/model.rs
+++ b/src/graphql/model.rs
@@ -2,7 +2,6 @@ use super::{
     cluster::TimeCount, data_source::DataSource, fill_vacant_time_slots, get_trend, slicing, Role,
     RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
 };
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     types::ID,
@@ -36,9 +35,6 @@ impl ModelQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, ModelDigest, ModelTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -11,7 +11,6 @@ use async_graphql::{
 use chrono::{DateTime, Utc};
 use review_database::{self as database};
 
-use crate::graphql::validate_and_process_pagination_params;
 use std::{convert::TryInto, mem::size_of};
 
 #[derive(Default)]
@@ -32,9 +31,6 @@ impl NetworkQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Network, NetworkTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -8,7 +8,6 @@ use super::{
     Node, NodeInput, NodeMutation, NodeQuery, NodeTotalCount, PortNumber, ServerAddress,
     ServerPort, Setting,
 };
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -35,9 +34,6 @@ impl NodeQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Node, NodeTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/outlier.rs
+++ b/src/graphql/outlier.rs
@@ -1,27 +1,22 @@
-use super::{always_true, model::ModelDigest, Role, RoleGuard, DEFAULT_CONNECTION_SIZE};
+use super::{encode_cursor, model::ModelDigest, Role, RoleGuard};
 use crate::graphql::validate_and_process_pagination_params;
-use crate::graphql::{earliest_key, latest_key};
-use anyhow::anyhow;
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     types::ID,
-    ComplexObject, Context, InputObject, Object, ObjectType, OutputType, Result, SimpleObject,
-    Subscription,
+    ComplexObject, Context, InputObject, Object, Result, SimpleObject, Subscription,
 };
 use bincode::Options;
 use chrono::{offset::LocalResult, DateTime, NaiveDateTime, TimeZone, Utc};
-use data_encoding::BASE64;
 use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::stream::Stream;
 use num_traits::ToPrimitive;
-use review_database::{types::FromKeyValue, Database, Direction, IterableMap, Store};
+use review_database::{Database, Direction, Store, UniqueKey};
 use serde::Deserialize;
 use serde::Serialize;
-use std::{cmp, collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use tokio::{sync::RwLock, time};
 use tracing::error;
 
-pub const TIMESTAMP_SIZE: usize = 8;
 const DEFAULT_OUTLIER_SIZE: usize = 50;
 const DISTANCE_EPSILON: f64 = 0.1;
 const DEFAULT_RANKED_OUTLIER_FETCH_TIME: u64 = 60;
@@ -85,24 +80,26 @@ async fn fetch_ranked_outliers(
 
         // Search for ranked outliers by model.
         for model_id in model_ids {
-            let prefix = bincode::DefaultOptions::new().serialize(&(model_id))?;
             let store = store.read().await;
-            let map = store.outlier_map().into_prefix_map(&prefix);
+            let map = store.outlier_map();
+
             let (iter, is_first_fetch) = if let Some(cursor) = latest_fetched_key.get(&model_id) {
-                (map.iter_from(cursor, Direction::Forward)?, false)
+                (
+                    map.get(model_id, None, Direction::Forward, Some(cursor)),
+                    false,
+                )
             } else {
-                (map.iter_forward()?, true)
+                (map.get(model_id, None, Direction::Forward, None), true)
             };
 
             let mut model_cursor = Vec::new();
-            for (k, v) in iter {
-                if let Some(value) = RankedOutlier::from_key_value(&k, &v)?.into() {
-                    if is_first_fetch && value.timestamp < start_time {
-                        continue;
-                    }
-                    model_cursor = k.to_vec();
-                    tx.unbounded_send(value)?;
-                };
+            for res in iter {
+                let entry = res?;
+                if is_first_fetch && entry.timestamp < start_time {
+                    continue;
+                }
+                model_cursor = entry.unique_key().to_vec();
+                tx.unbounded_send(entry.into())?;
             }
             if !model_cursor.is_empty() {
                 model_cursor.push(0);
@@ -123,22 +120,14 @@ impl OutlierMutation {
         ctx: &Context<'_>,
         #[graphql(validator(min_items = 1))] input: Vec<PreserveOutliersInput>,
     ) -> Result<usize> {
-        use bincode::Options;
         let store = super::get_store(ctx).await?;
         let map = store.outlier_map();
         let mut updated = vec![];
         for outlier_key in input {
             let outlier_id = (outlier_key.id, outlier_key.source.clone());
-            let key: RankedOutlierKey = outlier_key.into();
-            let key = bincode::DefaultOptions::new().serialize(&key)?;
-            if let Some(old) = map.get(&key)? {
-                let (distance, saved): RankedOutlierValue =
-                    bincode::DefaultOptions::new().deserialize(old.as_ref())?;
-                if !saved {
-                    let new = bincode::DefaultOptions::new().serialize(&(distance, true))?;
-                    map.update((&key, old.as_ref()), (&key, &new))?;
-                    updated.push(outlier_id);
-                }
+            let key: review_database::OutlierInfoKey = outlier_key.into();
+            if map.update_is_saved(&key)? {
+                updated.push(outlier_id);
             }
         }
 
@@ -188,17 +177,13 @@ impl OutlierQuery {
         last: Option<i32>,
     ) -> Result<Connection<String, Outlier, OutlierTotalCount, EmptyFields>> {
         let model = model.as_str().parse()?;
-        let filter = Some;
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,
             first,
             last,
             |after, before, first, last| async move {
-                load(ctx, model, after, before, first, last, filter).await
+                load(ctx, model, after, before, first, last).await
             },
         )
         .await
@@ -222,8 +207,6 @@ impl OutlierQuery {
         last: Option<i32>,
     ) -> Result<Connection<String, RankedOutlier, RankedOutlierTotalCount, EmptyFields>> {
         let filter = |node: RankedOutlier| if node.saved { Some(node) } else { None };
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
 
         load_outliers(ctx, model_id, time, after, before, first, last, filter).await
     }
@@ -246,9 +229,6 @@ impl OutlierQuery {
         last: Option<i32>,
         filter: Option<SearchFilterInput>,
     ) -> Result<Connection<String, RankedOutlier, RankedOutlierTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         load_ranked_outliers_with_filter(ctx, model_id, time, after, before, first, last, filter)
             .await
     }
@@ -268,28 +248,41 @@ async fn load_outliers(
     let model_id: i32 = model_id.as_str().parse()?;
     let timestamp = time.map(|t| t.and_utc().timestamp_nanos_opt().unwrap_or_default());
 
-    let prefix = if let Some(timestamp) = timestamp {
-        bincode::DefaultOptions::new().serialize(&(model_id, timestamp))?
-    } else {
-        bincode::DefaultOptions::new().serialize(&model_id)?
+    let prefix = {
+        let mut buf = model_id.to_be_bytes().to_vec();
+        if let Some(ts) = timestamp {
+            buf.extend(ts.to_be_bytes());
+        }
+        buf
     };
 
     let store = crate::graphql::get_store(ctx).await?;
-    let map = store.outlier_map().into_prefix_map(&prefix);
+    let map = store.outlier_map();
 
-    super::load_with_filter(
+    let (nodes, has_previous, has_next) = super::load_nodes(
         &map,
-        filter,
         after,
         before,
-        first,
-        last,
+        first.map(|value| usize::try_from(value).expect("valid size")),
+        last.map(|value| usize::try_from(value).expect("valid size")),
+        Some(&prefix),
+    )?;
+
+    let mut connection = Connection::with_additional_fields(
+        has_previous,
+        has_next,
         RankedOutlierTotalCount {
             model_id,
             timestamp,
             check_saved: true,
         },
-    )
+    );
+    connection.edges.extend(nodes.into_iter().filter_map(|n| {
+        let cursor = encode_cursor(&n.unique_key());
+        let n: RankedOutlier = n.into();
+        filter(n).map(|n| Edge::new(cursor, n))
+    }));
+    Ok(connection)
 }
 
 #[derive(Debug, SimpleObject)]
@@ -305,27 +298,24 @@ pub(super) struct RankedOutlier {
     saved: bool,
 }
 
+impl From<review_database::OutlierInfo> for RankedOutlier {
+    fn from(input: review_database::OutlierInfo) -> Self {
+        Self {
+            id: input.id,
+            model_id: input.model_id,
+            timestamp: input.timestamp,
+            rank: input.rank,
+            source: input.source,
+            distance: input.distance,
+            saved: input.is_saved,
+        }
+    }
+}
+
 #[ComplexObject]
 impl RankedOutlier {
     async fn id(&self) -> ID {
         ID(self.id.to_string())
-    }
-}
-
-impl FromKeyValue for RankedOutlier {
-    fn from_key_value(key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
-        let (model_id, timestamp, rank, id, source) =
-            bincode::DefaultOptions::new().deserialize(key)?;
-        let (distance, saved) = bincode::DefaultOptions::new().deserialize(value)?;
-        Ok(Self {
-            id,
-            model_id,
-            timestamp,
-            rank,
-            source,
-            distance,
-            saved,
-        })
     }
 }
 
@@ -338,17 +328,15 @@ struct PreserveOutliersInput {
     source: String,
 }
 
-type RankedOutlierKey = (i32, i64, i64, i64, String);
-type RankedOutlierValue = (f64, bool);
-impl From<PreserveOutliersInput> for RankedOutlierKey {
+impl From<PreserveOutliersInput> for review_database::OutlierInfoKey {
     fn from(input: PreserveOutliersInput) -> Self {
-        (
-            input.model_id,
-            input.timestamp,
-            input.rank,
-            input.id,
-            input.source,
-        )
+        Self {
+            model_id: input.model_id,
+            timestamp: input.timestamp,
+            rank: input.rank,
+            id: input.id,
+            source: input.source,
+        }
     }
 }
 
@@ -362,22 +350,17 @@ struct RankedOutlierTotalCount {
 impl RankedOutlierTotalCount {
     /// The total number of edges.
     async fn total_count(&self, ctx: &Context<'_>) -> Result<usize> {
-        use review_database::IterableMap;
-        let prefix = if let Some(timestamp) = self.timestamp {
-            bincode::DefaultOptions::new().serialize(&(self.model_id, timestamp))?
-        } else {
-            bincode::DefaultOptions::new().serialize(&self.model_id)?
-        };
         let store = crate::graphql::get_store(ctx).await?;
-        let map = store.outlier_map().into_prefix_map(&prefix);
+        let map = store.outlier_map();
 
-        let iter = map.iter_forward()?;
+        let iter = map.get(self.model_id, self.timestamp, Direction::Forward, None);
         let count = if self.check_saved {
-            iter.filter(|(_k, v)| {
-                let (_, saved): RankedOutlierValue = bincode::DefaultOptions::new()
-                    .deserialize(v)
-                    .unwrap_or_default();
-                saved
+            iter.filter(|res| {
+                if let Ok(entry) = res {
+                    entry.is_saved
+                } else {
+                    false
+                }
             })
             .count()
         } else {
@@ -396,43 +379,6 @@ pub(super) struct Outlier {
     pub(super) events: Vec<i64>,
     pub(super) size: i64,
     pub(super) model_id: i32,
-}
-
-pub trait FromKeys: Sized {
-    /// Creates a new instance from the given keys.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the key or value cannot be deserialized.
-    fn from_keys(keys: &[Box<[u8]>]) -> Result<Self>;
-}
-
-impl FromKeys for Outlier {
-    fn from_keys(keys: &[Box<[u8]>]) -> Result<Self> {
-        let size = i64::try_from(keys.len())?;
-        let mut events: Vec<i64> = Vec::new();
-        let keys: Vec<_> = keys.iter().take(DEFAULT_OUTLIER_SIZE).collect();
-
-        let Some(first_key) = keys.first() else {
-            return Err(anyhow!("Failed to read outlier's first key").into());
-        };
-        let (model_id, timestamp, _, event, _) =
-            bincode::DefaultOptions::new().deserialize::<RankedOutlierKey>(first_key)?;
-        events.push(event);
-
-        for key in keys {
-            let (_, _, _, event, _) =
-                bincode::DefaultOptions::new().deserialize::<RankedOutlierKey>(key)?;
-            events.push(event);
-        }
-        events.sort_unstable();
-        Ok(Self {
-            id: timestamp,
-            events,
-            size,
-            model_id,
-        })
-    }
 }
 
 #[ComplexObject]
@@ -462,36 +408,16 @@ struct OutlierTotalCount {
 #[Object]
 impl OutlierTotalCount {
     /// The total number of edges.
-    async fn total_count(&self, ctx: &Context<'_>) -> Result<i64> {
-        let prefix = bincode::DefaultOptions::new().serialize(&self.model_id)?;
+    async fn total_count(&self, ctx: &Context<'_>) -> Result<usize> {
+        use std::collections::HashSet;
         let store = crate::graphql::get_store(ctx).await?;
-        let map = store.outlier_map().into_prefix_map(&prefix);
-        let mut iter = map.iter_forward()?;
-        let mut total_cnt = 0;
-        let mut outlier_group = Vec::new();
+        let table = store.outlier_map();
+        let iter = table.get(self.model_id, None, Direction::Forward, None);
 
-        if let Some((first_k, _)) = iter.next() {
-            let mut outlier_group_key = get_ts_nano_from_key(&first_k)?;
-            outlier_group.push(first_k);
-            for (k, _) in iter {
-                let current_group_key = get_ts_nano_from_key(&k)?;
-                if outlier_group_key == current_group_key {
-                    outlier_group.push(k);
-                    continue;
-                }
-                if Outlier::from_keys(&outlier_group).is_ok() {
-                    total_cnt += 1;
-                }
-                outlier_group.clear();
-                outlier_group.push(k);
-                outlier_group_key = current_group_key;
-            }
-        }
-
-        if !outlier_group.is_empty() && Outlier::from_keys(&outlier_group).is_ok() {
-            total_cnt += 1;
-        }
-        Ok(total_cnt)
+        Ok(iter
+            .map(|res| res.map(|entry| entry.timestamp).map_err(Into::into))
+            .collect::<Result<HashSet<_>>>()?
+            .len())
     }
 }
 
@@ -502,178 +428,93 @@ async fn load(
     before: Option<String>,
     first: Option<usize>,
     last: Option<usize>,
-    filter: fn(Outlier) -> Option<Outlier>,
 ) -> Result<Connection<String, Outlier, OutlierTotalCount, EmptyFields>> {
-    let prefix = bincode::DefaultOptions::new().serialize(&model_id)?;
     let store = crate::graphql::get_store(ctx).await?;
-    let map = store.outlier_map().into_prefix_map(&prefix);
+    let table = store.outlier_map();
 
-    load_with_all_outlier(
-        &map,
+    let (after, before, first, last) = validate_and_process_pagination_params(
         after,
         before,
-        first,
-        last,
-        filter,
-        OutlierTotalCount { model_id },
-    )
-}
-
-fn load_with_all_outlier<'m, M, I, N, NI, T>(
-    map: &'m M,
-    after: Option<String>,
-    before: Option<String>,
-    first: Option<usize>,
-    last: Option<usize>,
-    filter: fn(N) -> Option<N>,
-    total_count: T,
-) -> Result<Connection<String, N, T, EmptyFields>>
-where
-    M: IterableMap<'m, I>,
-    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'm,
-    N: From<NI> + OutputType,
-    NI: FromKeys,
-    T: ObjectType,
-{
-    let (nodes, has_previous, has_next) =
-        load_nodes_with_all_outlier(map, after, before, first, last, filter)?;
-
-    let mut connection = Connection::with_additional_fields(has_previous, has_next, total_count);
-    connection
-        .edges
-        .extend(nodes.into_iter().map(|(k, ev)| Edge::new(k, ev)));
-    Ok(connection)
-}
-
-#[allow(clippy::type_complexity)] // since this is called within `load` only
-fn load_nodes_with_all_outlier<'m, M, I, N, NI>(
-    map: &'m M,
-    after: Option<String>,
-    before: Option<String>,
-    first: Option<usize>,
-    last: Option<usize>,
-    filter: fn(N) -> Option<N>,
-) -> Result<(Vec<(String, N)>, bool, bool)>
-where
-    M: IterableMap<'m, I>,
-    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'm,
-    N: From<NI> + OutputType,
-    NI: FromKeys,
-{
-    if let Some(last) = last {
-        let iter = if let Some(before) = before {
-            let end = latest_outlier_key(&before)?;
-            map.iter_from(&end, Direction::Reverse)?
-        } else {
-            map.iter_backward()?
-        };
-
-        let (nodes, has_more) = if let Some(after) = after {
-            let to = earliest_outlier_key(&after)?;
-            iter_to_nodes_with_outlier(iter, &to, cmp::Ordering::is_ge, last, filter, true)
-        } else {
-            iter_to_nodes_with_outlier(iter, &[], always_true, last, filter, true)
-        }?;
-        Ok((nodes, has_more, false))
+        first.map(|value| i32::try_from(value).expect("valid size")),
+        last.map(|value| i32::try_from(value).expect("valid size")),
+    )?;
+    let decoded_after = after
+        .as_deref()
+        .map(|input| bincode::DefaultOptions::new().deserialize(input))
+        .transpose()?
+        .map(|(_, from): (&[u8], &[u8])| from);
+    let decoded_before = before
+        .as_deref()
+        .map(|input| bincode::DefaultOptions::new().deserialize(input))
+        .transpose()?
+        .map(|(from, _): (&[u8], &[u8])| from);
+    let (direction, count, from, to) = if let Some(first) = first {
+        (
+            Direction::Forward,
+            first.to_usize().expect("valid size"),
+            decoded_after,
+            decoded_before,
+        )
+    } else if let Some(last) = last {
+        (
+            Direction::Reverse,
+            last.to_usize().expect("valid size"),
+            decoded_before,
+            decoded_after,
+        )
     } else {
-        let first = first.unwrap_or(DEFAULT_CONNECTION_SIZE);
-        let iter = if let Some(after) = after {
-            let start = earliest_outlier_key(&after)?;
-            map.iter_from(&start, Direction::Forward)?
-        } else {
-            map.iter_forward()?
-        };
+        unreachable!();
+    };
 
-        let (nodes, has_more) = if let Some(before) = before {
-            let to = latest_outlier_key(&before)?;
-            iter_to_nodes_with_outlier(iter, &to, cmp::Ordering::is_le, first, filter, false)
-        } else {
-            iter_to_nodes_with_outlier(iter, &[], always_true, first, filter, false)
-        }?;
-        Ok((nodes, false, has_more))
-    }
-}
+    let iter = table.get(model_id, None, direction, from);
 
-fn iter_to_nodes_with_outlier<I, N, NI>(
-    mut iter: I,
-    to: &[u8],
-    cond: fn(cmp::Ordering) -> bool,
-    len: usize,
-    filter: fn(N) -> Option<N>,
-    is_reverse: bool,
-) -> Result<(Vec<(String, N)>, bool)>
-where
-    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)>,
-    N: From<NI>,
-    NI: FromKeys,
-{
-    let mut nodes = Vec::new();
-    let mut exceeded = false;
-    let mut outlier_group = Vec::new();
-
-    if let Some((first_k, _)) = iter.next() {
-        if !(cond)(first_k.as_ref().cmp(to)) {
-            return Ok((nodes, exceeded));
+    let mut batches = HashMap::new();
+    let mut has_more = false;
+    for res in iter {
+        let entry = res?;
+        if !batches.contains_key(&entry.timestamp) && batches.len() >= count {
+            has_more = true;
+            break;
         }
-        let mut outlier_group_key = get_ts_nano_from_key(&first_k)?;
-        let encoded_key = BASE64.encode(&first_k);
-        let (mut start_cursor, mut end_cursor) = (encoded_key.clone(), encoded_key);
-        outlier_group.push(first_k);
-
-        for (k, _) in iter {
-            if !(cond)(k.as_ref().cmp(to)) {
+        let key = entry.unique_key().to_vec();
+        if let Some(to) = to {
+            if key == to {
                 break;
             }
-            let current_group_key = get_ts_nano_from_key(&k)?;
-            if outlier_group_key == current_group_key {
-                end_cursor = BASE64.encode(&k);
-                outlier_group.push(k);
-                continue;
-            }
-
-            if is_reverse {
-                (start_cursor, end_cursor) = (end_cursor, start_cursor);
-                outlier_group.reverse();
-            }
-
-            let Some(node) = filter(NI::from_keys(&outlier_group)?.into()) else {
-                let encoded_key = BASE64.encode(&k);
-                (start_cursor, end_cursor) = (encoded_key.clone(), encoded_key);
-                outlier_group.clear();
-                outlier_group.push(k);
-                outlier_group_key = current_group_key;
-                continue;
-            };
-
-            nodes.push((format!("{start_cursor}:{end_cursor}"), node));
-            exceeded = nodes.len() > len;
-            if exceeded {
-                outlier_group.clear();
-                break;
-            }
-
-            let encoded_key = BASE64.encode(&k);
-            (start_cursor, end_cursor) = (encoded_key.clone(), encoded_key);
-            outlier_group.clear();
-            outlier_group.push(k);
-            outlier_group_key = current_group_key;
         }
 
-        if !outlier_group.is_empty() {
-            if is_reverse {
-                (start_cursor, end_cursor) = (end_cursor, start_cursor);
-                outlier_group.reverse();
-            }
-            if let Some(node) = filter(NI::from_keys(&outlier_group)?.into()) {
-                nodes.push((format!("{start_cursor}:{end_cursor}"), node));
-            }
+        let batch = batches.entry(entry.timestamp).or_insert((
+            key.clone(),
+            vec![],
+            Outlier {
+                model_id,
+                events: vec![],
+                id: entry.timestamp,
+                size: 0,
+            },
+        ));
+        batch.1 = key;
+        batch.2.size += 1;
+        if batch.2.events.len() < DEFAULT_OUTLIER_SIZE {
+            batch.2.events.push(entry.id);
         }
     }
 
-    if exceeded {
-        nodes.pop();
-    }
-    Ok((nodes, exceeded))
+    let (has_previous, has_next) = if first.is_some() {
+        (false, has_more)
+    } else {
+        (has_more, false)
+    };
+    let edges = batches.into_values().filter_map(|(from, to, mut ev)| {
+        let cursor = bincode::DefaultOptions::new().serialize(&(from, to)).ok()?;
+        let encoded = super::encode_cursor(&cursor);
+        ev.events.sort_unstable();
+        Some(Edge::new(encoded, ev))
+    });
+    let mut connection =
+        Connection::with_additional_fields(has_previous, has_next, OutlierTotalCount { model_id });
+    connection.edges.extend(edges);
+    Ok(connection)
 }
 
 pub(crate) fn datetime_from_ts_nano(time: i64) -> Option<DateTime<Utc>> {
@@ -686,48 +527,7 @@ pub(crate) fn datetime_from_ts_nano(time: i64) -> Option<DateTime<Utc>> {
     }
 }
 
-pub fn get_ts_nano_from_key(key: &[u8]) -> Result<i64, anyhow::Error> {
-    if key.len() > TIMESTAMP_SIZE {
-        let (_, ts_nano, _, _, _) =
-            bincode::DefaultOptions::new().deserialize::<RankedOutlierKey>(key)?;
-        return Ok(ts_nano);
-    }
-    Err(anyhow!("invalid database key length"))
-}
-
-fn earliest_outlier_key(after: &str) -> Result<Vec<u8>> {
-    let Some((_, last_k)) = after.split_once(':') else {
-        return Err(anyhow!("Failed to parse outlier's after key").into());
-    };
-
-    let mut start = BASE64
-        .decode(last_k.as_bytes())
-        .map_err(|_| "invalid cursor `after`")?;
-    start.push(0);
-    Ok(start)
-}
-
-fn latest_outlier_key(before: &str) -> Result<Vec<u8>> {
-    let Some((start_k, _)) = before.split_once(':') else {
-        return Err(anyhow!("Failed to parse outlier's before key").into());
-    };
-
-    let mut end = BASE64
-        .decode(start_k.as_bytes())
-        .map_err(|_| "invalid cursor `before`")?;
-    let last_byte = if let Some(b) = end.last_mut() {
-        *b
-    } else {
-        return Err("invalid cursor `before`".into());
-    };
-    end.pop();
-    if last_byte > 0 {
-        end.push(last_byte - 1);
-    }
-    Ok(end)
-}
-
-#[allow(clippy::too_many_arguments, clippy::type_complexity)] // since this is called within `load` only
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 async fn load_ranked_outliers_with_filter(
     ctx: &Context<'_>,
     model_id: ID,
@@ -740,144 +540,43 @@ async fn load_ranked_outliers_with_filter(
 ) -> Result<Connection<String, RankedOutlier, RankedOutlierTotalCount, EmptyFields>> {
     let model_id: i32 = model_id.as_str().parse()?;
     let timestamp = time.map(|t| t.and_utc().timestamp_nanos_opt().unwrap_or_default());
-
-    let prefix = if let Some(timestamp) = timestamp {
-        bincode::DefaultOptions::new().serialize(&(model_id, timestamp))?
+    let (after, before, first, last) =
+        validate_and_process_pagination_params(after, before, first, last)?;
+    let (direction, count, from, to) = if let Some(first) = first {
+        (
+            Direction::Forward,
+            first.to_usize().expect("valid size"),
+            after.as_deref(),
+            before.as_deref(),
+        )
+    } else if let Some(last) = last {
+        (
+            Direction::Reverse,
+            last.to_usize().expect("valid size"),
+            before.as_deref(),
+            after.as_deref(),
+        )
     } else {
-        bincode::DefaultOptions::new().serialize(&model_id)?
+        unreachable!();
     };
 
     let store = crate::graphql::get_store(ctx).await?;
-    let map = store.outlier_map().into_prefix_map(&prefix);
+    let table = store.outlier_map();
+
     let remarks_map = store.triage_response_map();
     let tags_map = store.event_tag_set()?;
 
-    let (nodes, has_previous, has_next) = load_nodes_with_search_filter(
-        &map,
-        &remarks_map,
-        &tags_map,
-        &filter,
-        after,
-        before,
-        first.and_then(|f| f.to_usize()),
-        last.and_then(|l| l.to_usize()),
-    )?;
+    let mut has_more = false;
+    let mut nodes = vec![];
+    let additional = RankedOutlierTotalCount {
+        model_id,
+        timestamp,
+        check_saved: false,
+    };
 
-    let mut connection = Connection::with_additional_fields(
-        has_previous,
-        has_next,
-        RankedOutlierTotalCount {
-            model_id,
-            timestamp,
-            check_saved: false,
-        },
-    );
-    connection
-        .edges
-        .extend(nodes.into_iter().map(|(k, ev)| Edge::new(k, ev)));
-    Ok(connection)
-}
-
-#[allow(clippy::type_complexity, clippy::too_many_arguments)] // since this is called within `load` only
-fn load_nodes_with_search_filter<'m, M, I, T>(
-    map: &'m M,
-    remarks_map: &review_database::IndexedTable<'_, review_database::TriageResponse>,
-    tags_map: &review_database::TagSet<'_, T>,
-    filter: &Option<SearchFilterInput>,
-    after: Option<String>,
-    before: Option<String>,
-    first: Option<usize>,
-    last: Option<usize>,
-) -> Result<(Vec<(String, RankedOutlier)>, bool, bool)>
-where
-    M: IterableMap<'m, I>,
-    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'm,
-{
-    if let Some(last) = last {
-        let iter = if let Some(before) = before {
-            let end = latest_key(&before)?;
-            map.iter_from(&end, Direction::Reverse)?
-        } else {
-            map.iter_backward()?
-        };
-
-        let (nodes, has_more) = if let Some(after) = after {
-            let to = earliest_key(&after)?;
-            iter_through_search_filter_nodes(
-                iter,
-                remarks_map,
-                tags_map,
-                &to,
-                cmp::Ordering::is_ge,
-                filter,
-                last,
-            )
-        } else {
-            iter_through_search_filter_nodes(
-                iter,
-                remarks_map,
-                tags_map,
-                &[],
-                always_true,
-                filter,
-                last,
-            )
-        }?;
-        Ok((nodes, has_more, false))
-    } else {
-        let first = first.unwrap_or(DEFAULT_CONNECTION_SIZE);
-        let iter = if let Some(after) = after {
-            let start = earliest_key(&after)?;
-            map.iter_from(&start, Direction::Forward)?
-        } else {
-            map.iter_forward()?
-        };
-
-        let (nodes, has_more) = if let Some(before) = before {
-            let to = latest_key(&before)?;
-            iter_through_search_filter_nodes(
-                iter,
-                remarks_map,
-                tags_map,
-                &to,
-                cmp::Ordering::is_le,
-                filter,
-                first,
-            )
-        } else {
-            iter_through_search_filter_nodes(
-                iter,
-                remarks_map,
-                tags_map,
-                &[],
-                always_true,
-                filter,
-                first,
-            )
-        }?;
-        Ok((nodes, false, has_more))
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-fn iter_through_search_filter_nodes<I, T>(
-    iter: I,
-    remarks_map: &review_database::IndexedTable<'_, review_database::TriageResponse>,
-    tag_set: &review_database::TagSet<'_, T>,
-    to: &[u8],
-    cond: fn(cmp::Ordering) -> bool,
-    filter: &Option<SearchFilterInput>,
-    len: usize,
-) -> Result<(Vec<(String, RankedOutlier)>, bool)>
-where
-    I: Iterator<Item = (Box<[u8]>, Box<[u8]>)>,
-{
-    let mut nodes = Vec::new();
-    let mut exceeded = false;
-
-    let tag_id_list = if let Some(filter) = filter {
+    let tag_id_list = if let Some(filter) = &filter {
         if let Some(pattern) = &filter.tag {
-            let tag_ids = tag_set
+            let tag_ids = tags_map
                 .tags()
                 .filter_map(|tag| {
                     if tag.name.contains(pattern) {
@@ -888,7 +587,7 @@ where
                 })
                 .collect::<Vec<_>>();
             if tag_ids.is_empty() {
-                return Ok((nodes, exceeded));
+                return Ok(Connection::with_additional_fields(false, false, additional));
             }
             Some(tag_ids)
         } else {
@@ -898,17 +597,22 @@ where
         None
     };
 
-    for (k, v) in iter {
-        if !(cond)(k.as_ref().cmp(to)) {
-            break;
+    for res in table.get(model_id, timestamp, direction, from) {
+        let node = res?;
+        let key = node.unique_key();
+
+        if let Some(to) = to {
+            if to == key.as_ref() {
+                continue;
+            }
         }
-
-        let curser = BASE64.encode(&k);
-        let Some(node) = RankedOutlier::from_key_value(&k, &v)?.into() else {
+        if nodes.len() >= count {
+            has_more = true;
             continue;
-        };
+        }
+        let encoded_key = encode_cursor(&key);
 
-        if let Some(filter) = filter {
+        if let Some(filter) = &filter {
             if filter.remark.is_some() || tag_id_list.is_some() {
                 if let Some(value) = remarks_map.get(&node.source, &Utc.timestamp_nanos(node.id))? {
                     if let Some(remark) = &filter.remark {
@@ -955,16 +659,330 @@ where
                 }
             }
         }
+        nodes.push((encoded_key, node));
+    }
 
-        nodes.push((curser, node));
-        exceeded = nodes.len() > len;
-        if exceeded {
-            break;
+    let (has_previous, has_next) = if first.is_some() {
+        (false, has_more)
+    } else {
+        (has_more, false)
+    };
+
+    let mut connection = Connection::with_additional_fields(has_previous, has_next, additional);
+    connection
+        .edges
+        .extend(nodes.into_iter().map(|(k, ev)| Edge::new(k, ev.into())));
+    Ok(connection)
+}
+
+#[cfg(test)]
+mod tests {
+    use async_graphql::Value;
+    use chrono::{DateTime, Utc};
+    use review_database::OutlierInfo;
+
+    use crate::graphql::TestSchema;
+
+    fn time_str(t: &DateTime<Utc>) -> String {
+        t.format("%FT%T%.9f").to_string()
+    }
+
+    fn samples(model_id: i32, timestamp: i64, start: i64, total: i64) -> Vec<OutlierInfo> {
+        (start..start + total)
+            .into_iter()
+            .map(|id| {
+                let rank = id;
+                let distance = id as f64;
+                let is_saved = id % 2 == 0;
+                OutlierInfo {
+                    model_id,
+                    timestamp,
+                    rank,
+                    id,
+                    source: "test".to_string(),
+                    distance,
+                    is_saved,
+                }
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn outliers() {
+        let schema = TestSchema::new().await;
+        let store = schema.store().await;
+        let map = store.outlier_map();
+        let model = 3;
+        let t1 = chrono::Utc::now();
+        let outliers = samples(model, t1.timestamp_nanos_opt().unwrap(), 0, 2);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
         }
+        let res = schema
+            .execute(
+                r#"query {
+                outliers(model: 3) {
+                    nodes {id, events, size},
+                    totalCount
+                }
+            }"#,
+            )
+            .await;
+        let e0 = DateTime::from_timestamp(0, 0).unwrap().to_rfc3339();
+        let e1 = DateTime::from_timestamp(0, 1).unwrap().to_rfc3339();
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{outliers: {{nodes: [{{id: \"{}\",events: [\"{e0}\",\"{e1}\"],size: 2}}],totalCount: {}}}}}", t1.timestamp_nanos_opt().unwrap(), 1)
+        );
+
+        let t2 = t1 + chrono::TimeDelta::hours(1);
+        let start = 3;
+        let total = 4;
+
+        let outliers = samples(model, t2.timestamp_nanos_opt().unwrap(), start, total);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
+        }
+
+        let res = schema
+            .execute(
+                r#"query {
+                    outliers(model: 3) {
+                        totalCount
+                    }
+                }"#,
+            )
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{outliers: {{totalCount: {}}}}}", 2)
+        );
     }
 
-    if exceeded {
-        nodes.pop();
+    #[tokio::test]
+    async fn ranked_outliers() {
+        let schema = TestSchema::new().await;
+        let store = schema.store().await;
+        let map = store.outlier_map();
+        let model = 3;
+        let t1 = chrono::Utc::now();
+        let outliers = samples(model, t1.timestamp_nanos_opt().unwrap(), 0, 2);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
+        }
+
+        let res = schema
+            .execute(
+                r#"query {
+                    rankedOutliers(modelId: 3) {
+                        totalCount
+                    }
+                }"#,
+            )
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{rankedOutliers: {{totalCount: {}}}}}", outliers.len())
+        );
+
+        let t2 = t1 + chrono::TimeDelta::hours(1);
+        let t2_str = time_str(&t2);
+        let start = 3;
+        let total = 4;
+        let last = start + total - 1;
+
+        let outliers = samples(model, t2.timestamp_nanos_opt().unwrap(), start, total);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
+        }
+
+        let res = schema
+            .execute(&format!(
+                "query {{rankedOutliers(modelId: 3, time: \"{}\", first: 1) {{ nodes {{ id }} }} }}",
+                &t2_str
+            ))
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{rankedOutliers: {{nodes: [{{id: \"{}\"}}]}}}}", 3)
+        );
+
+        let res = schema
+            .execute(&format!(
+                "query {{rankedOutliers(modelId: 3, time: \"{}\", first: 3) {{ pageInfo {{
+                hasNextPage,
+                startCursor,
+                endCursor
+            }} }} }}",
+                &t2_str
+            ))
+            .await;
+        let Value::Object(retval) = res.data else {
+            panic!("unexpected response: {:?}", res);
+        };
+        let Some(Value::Object(ranked_outliers)) = retval.get("rankedOutliers") else {
+            panic!("unexpected response: {:?}", retval);
+        };
+        let Some(Value::Object(page_info)) = ranked_outliers.get("pageInfo") else {
+            panic!("unexpected response: {:?}", ranked_outliers);
+        };
+        let Some(Value::Boolean(has_next_page)) = page_info.get("hasNextPage") else {
+            panic!("unexpected response: {:?}", page_info);
+        };
+        assert_eq!(*has_next_page, true);
+        let Some(Value::String(cursor)) = page_info.get("endCursor") else {
+            panic!("unexpected response: {:?}", page_info);
+        };
+
+        let res = schema
+            .execute(&format!(
+                "query {{rankedOutliers(modelId: 3, time: \"{}\", after: \"{cursor}\", first: 1) {{ nodes {{ id }} }} }}",
+                &t2_str
+            ))
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{rankedOutliers: {{nodes: [{{id: \"{}\"}}]}}}}", last - 1,)
+        );
+
+        let res = schema
+            .execute(&format!(
+                "query {{rankedOutliers(modelId: 3, time: \"{}\", last: 2) {{ nodes {{ id }} }} }}",
+                &t2_str
+            ))
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!(
+                "{{rankedOutliers: {{nodes: [{{id: \"{}\"}},{{id: \"{}\"}}]}}}}",
+                last,
+                last - 1
+            )
+        );
+
+        let res = schema
+            .execute(&format!(
+                "query {{rankedOutliers(modelId: 3, time: \"{}\", last: 3) {{ pageInfo {{
+            hasPreviousPage,
+            startCursor,
+            endCursor
+        }} }} }}",
+                &t2_str
+            ))
+            .await;
+        let Value::Object(retval) = res.data else {
+            panic!("unexpected response: {:?}", res);
+        };
+        let Some(Value::Object(ranked_outliers)) = retval.get("rankedOutliers") else {
+            panic!("unexpected response: {:?}", retval);
+        };
+        let Some(Value::Object(page_info)) = ranked_outliers.get("pageInfo") else {
+            panic!("unexpected response: {:?}", ranked_outliers);
+        };
+        let Some(Value::Boolean(has_previous_page)) = page_info.get("hasPreviousPage") else {
+            panic!("unexpected response: {:?}", page_info);
+        };
+        assert_eq!(*has_previous_page, true);
+        let Some(Value::String(cursor)) = page_info.get("endCursor") else {
+            panic!("unexpected response: {:?}", page_info);
+        };
+
+        let res = schema
+        .execute(&format!(
+            "query {{rankedOutliers(modelId: 3, time: \"{}\", before: \"{cursor}\", last: 1) {{ nodes {{ id }} }} }}",
+            &t2_str
+        ))
+        .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{rankedOutliers: {{nodes: [{{id: \"{}\"}}]}}}}", start + 1,)
+        );
     }
-    Ok((nodes, exceeded))
+
+    #[tokio::test]
+    async fn saved_outliers() {
+        let schema = TestSchema::new().await;
+        let store = schema.store().await;
+        let map = store.outlier_map();
+
+        let t = chrono::Utc::now();
+        let t_str = time_str(&t);
+        let outliers = samples(0, t.timestamp_nanos_opt().unwrap(), 0, 2);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
+        }
+
+        let model = 3;
+
+        let start = 3;
+        let total = 4;
+
+        let outliers = samples(model, t.timestamp_nanos_opt().unwrap(), start, total);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
+        }
+
+        let res = schema
+            .execute(&format!(
+                "query {{savedOutliers(modelId: {model}, time: \"{}\") {{ totalCount }} }}",
+                &t_str
+            ))
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{savedOutliers: {{totalCount: {}}}}}", total / 2)
+        );
+    }
+
+    #[tokio::test]
+    async fn preserved_outliers() {
+        let schema = TestSchema::new().await;
+        let store = schema.store().await;
+        let map = store.outlier_map();
+
+        let t = chrono::Utc::now();
+        let t_str = time_str(&t);
+
+        let model = 3;
+
+        let start = 3;
+        let total = 4;
+
+        let outliers = samples(model, t.timestamp_nanos_opt().unwrap(), start, total);
+        for outlier in &outliers {
+            assert!(map.insert(&outlier).is_ok());
+        }
+
+        let res = schema
+            .execute(&format!(
+                "query {{savedOutliers(modelId: {model}, time: \"{}\") {{ totalCount }} }}",
+                &t_str
+            ))
+            .await;
+        assert_eq!(
+            res.data.to_string(),
+            format!("{{savedOutliers: {{totalCount: {}}}}}", total / 2)
+        );
+
+        let to_save = start;
+        let to_preserve = format!("[{{id: {to_save}, modelId: {model}, timestamp: {}, rank: {to_save}, source: \"test\"}}]", t.timestamp_nanos_opt().unwrap());
+        let res = schema
+            .execute(&format!(
+                "mutation {{preserveOutliers(input: {to_preserve})}}"
+            ))
+            .await;
+        assert_eq!(res.data.to_string(), "{preserveOutliers: 1}");
+
+        let saved = start + 1;
+        let to_preserve = format!(
+            "[{{id: {saved}, modelId: {model}, timestamp: {}, rank: {saved}, source: \"test\"}}]",
+            t.timestamp_nanos_opt().unwrap()
+        );
+        let res = schema
+            .execute(&format!(
+                "mutation {{preserveOutliers(input: {to_preserve})}}"
+            ))
+            .await;
+        assert_eq!(res.data.to_string(), "{preserveOutliers: 0}");
+    }
 }

--- a/src/graphql/qualifier.rs
+++ b/src/graphql/qualifier.rs
@@ -1,5 +1,4 @@
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -28,9 +27,6 @@ impl QualifierQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Qualifier, QualifierTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -1,5 +1,4 @@
 use super::{BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -238,9 +237,6 @@ impl SamplingPolicyQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, SamplingPolicy, SamplingPolicyTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/statistics.rs
+++ b/src/graphql/statistics.rs
@@ -1,5 +1,4 @@
 use super::{slicing, Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, ConnectionNameType, Edge, EmptyFields},
     types::ID,
@@ -45,8 +44,6 @@ impl StatisticsQuery {
         last: Option<i32>,
     ) -> Result<Connection<String, Round, TotalCountByCluster, EmptyFields, RoundByCluster>> {
         let cluster = cluster.as_str().parse()?;
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
 
         query(
             after,
@@ -74,8 +71,6 @@ impl StatisticsQuery {
         last: Option<i32>,
     ) -> Result<Connection<String, Round, TotalCountByModel, EmptyFields, RoundByModel>> {
         let model = model.as_str().parse()?;
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
 
         query(
             after,

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -1,5 +1,4 @@
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -28,9 +27,6 @@ impl StatusQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Status, StatusTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/template.rs
+++ b/src/graphql/template.rs
@@ -1,5 +1,4 @@
 use super::{ParseEnumError, Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, Enum, InputObject, Object, Result, Union,
@@ -25,9 +24,6 @@ impl TemplateQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Template, TemplateTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/tor_exit_node.rs
+++ b/src/graphql/tor_exit_node.rs
@@ -1,5 +1,4 @@
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
@@ -25,9 +24,6 @@ impl TorExitNodeQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TorExitNode, TorExitNodeTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/triage/policy.rs
+++ b/src/graphql/triage/policy.rs
@@ -3,7 +3,6 @@ use super::{
     TriagePolicyMutation, TriagePolicyQuery,
 };
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, Object, Result, ID,
@@ -35,9 +34,6 @@ impl TriagePolicyQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TriagePolicy, TriagePolicyTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/triage/response.rs
+++ b/src/graphql/triage/response.rs
@@ -1,5 +1,4 @@
 use super::{Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     types::ID,
@@ -73,9 +72,6 @@ impl super::TriageResponseQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TriageResponse, TriageResponseTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -1,5 +1,4 @@
 use super::{AgentManager, BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
@@ -23,9 +22,6 @@ impl TrustedDomainQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TrustedDomain, EmptyFields, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,

--- a/src/graphql/trusted_user_agent.rs
+++ b/src/graphql/trusted_user_agent.rs
@@ -1,5 +1,4 @@
 use super::{BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::validate_and_process_pagination_params;
 use anyhow::Context as _;
 use async_graphql::{
     connection::{query, Connection, EmptyFields},
@@ -28,9 +27,6 @@ impl UserAgentQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TrustedUserAgent, TrustedUserAgentTotalCount, EmptyFields>> {
-        let (after, before, first, last) =
-            validate_and_process_pagination_params(after, before, first, last)?;
-
         query(
             after,
             before,


### PR DESCRIPTION
The PR adjusts `review-web` to the updated `outlier` map interface from `review-database` where `Map` is no longer exposed and the key is stored differently. To fit in, the following modifications have been made.
* `load_nodes`, `load_nodes_with_filter`, `load_with_filter`, `iter_to_nodes_with_filter` are refactored for clarity.
* `validate_and_process_pagination_params` as a validation process for `load_edges` and `load_edges` is excluded from individual query (before the load function call) to avoid duplicated decoding error.
* Switches cursor encoding format from `encode(before):encode(after)` to `encode(serialize(&(before,after)))` for security for `outlier::load`.
* Refactors `outlier::load_ranked_outliers_with_filter`, `outlier::load_with_all_outlier` and functions related for simplification