### PR TITLE
Refactor code structure and expose `Config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `Config` to the public API under the `backend` module to ensure all
+  types used by the public traits `AgentManager` and `CertManager` are
+  accessible.
+
 ### Changed
 
 - Change admin account to read environment variable `REVIEW_ADMIN` from hardcoded
   value.
+- Moved `AgentManager` and `CertManager` traits from the `graphql` module to a
+  newly created `backend` module. This change better organizes the code
+  structure by separating concerns, as these traits are not directly related to
+  the GraphQL API but are instead utilized within it.
 
 ### Fixed
 

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -9,8 +9,8 @@ use ipnet::IpNet;
 use review_database::{migrate_data_dir, Database, Store};
 use review_web::{
     self as web,
-    graphql::{AgentManager, Process, ResourceUsage, SamplingPolicy},
-    CertManager,
+    backend::{AgentManager, CertManager},
+    graphql::{Process, ResourceUsage, SamplingPolicy},
 };
 use serde::Deserialize;
 use std::{

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,105 @@
+pub use crate::graphql::{ParsedCertificate, SamplingPolicy};
+use anyhow::anyhow;
+use async_trait::async_trait;
+use ipnet::IpNet;
+pub use review_protocol::types::Config;
+pub use roxy::{Process, ResourceUsage};
+use std::{collections::HashMap, path::PathBuf};
+
+#[async_trait]
+pub trait AgentManager: Send + Sync {
+    async fn broadcast_trusted_domains(&self) -> Result<(), anyhow::Error> {
+        Err(anyhow!("Not supported"))
+    }
+
+    async fn broadcast_internal_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error>;
+
+    async fn broadcast_allow_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error>;
+
+    async fn broadcast_block_networks(
+        &self,
+        _networks: &[u8],
+    ) -> Result<Vec<String>, anyhow::Error>;
+
+    async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
+        Err(anyhow!("Not supported"))
+    }
+
+    async fn online_apps_by_host_id(
+        &self,
+    ) -> Result<HashMap<String, Vec<(String, String)>>, anyhow::Error>; // (hostname, (agent_key, app_name))
+
+    async fn broadcast_crusher_sampling_policy(
+        &self,
+        _sampling_policies: &[SamplingPolicy],
+    ) -> Result<(), anyhow::Error>;
+
+    /// Returns the configuration of the given agent.
+    async fn get_config(&self, _hostname: &str, _agent_id: &str) -> Result<Config, anyhow::Error>;
+
+    /// Returns the list of processes running on the given host.
+    async fn get_process_list(&self, _hostname: &str) -> Result<Vec<Process>, anyhow::Error>;
+
+    /// Returns the resource usage of the given host.
+    async fn get_resource_usage(&self, _hostname: &str) -> Result<ResourceUsage, anyhow::Error>;
+
+    /// Halts the node with the given hostname.
+    async fn halt(&self, _hostname: &str) -> Result<(), anyhow::Error>;
+
+    /// Sends a ping message to the given host and waits for a response. Returns
+    /// the round-trip time in microseconds.
+    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error>;
+
+    /// Reboots the node with the given hostname.
+    async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error>;
+
+    /// Sets the configuration of the given agent.
+    async fn set_config(
+        &self,
+        _hostname: &str,
+        _agent_id: &str,
+        _config: &Config,
+    ) -> Result<(), anyhow::Error>;
+
+    /// Updates the traffic filter rules for the given host.
+    async fn update_traffic_filter_rules(
+        &self,
+        _host: &str,
+        _rules: &[(IpNet, Option<Vec<u16>>, Option<Vec<u16>>)],
+    ) -> Result<(), anyhow::Error> {
+        Err(anyhow!("Not supported"))
+    }
+}
+
+pub trait CertManager: Send + Sync {
+    /// Returns the certificate path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the certificate path cannot be determined.
+    fn cert_path(&self) -> Result<PathBuf, anyhow::Error>;
+
+    /// Returns the key path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the key path cannot be determined.
+    fn key_path(&self) -> Result<PathBuf, anyhow::Error>;
+
+    /// Updates the certificate and key.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the certificate and key cannot be updated.
+    fn update_certificate(
+        &self,
+        cert: String,
+        key: String,
+    ) -> Result<Vec<ParsedCertificate>, anyhow::Error>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod archive;
 pub mod auth;
+pub mod backend;
 pub mod graphql;
 
 use crate::auth::{validate_token, AuthError};
+use crate::backend::{AgentManager, CertManager};
 use async_graphql::{
     http::{playground_source, GraphQLPlaygroundConfig},
     Data,
@@ -17,8 +19,7 @@ use axum::{
     routing::{get, get_service},
     Json, Router,
 };
-pub use graphql::CertManager;
-use graphql::{AgentManager, RoleGuard};
+use graphql::RoleGuard;
 use review_database::{Database, Store};
 use rustls::{Certificate, ClientConfig, RootCertStore};
 use serde_json::json;


### PR DESCRIPTION
This pull request refactors the structure of `review-web` to improve clarity and usability. Specifically, it relocates the `AgentManager` and `CertManager` traits from the `graphql` module to a new `backend` module. Additionally, it exposes the `Config` type in the public API to ensure all types used by the public traits are accessible.

### Rationale

The `AgentManager` and `CertManager` traits, while utilized in the context of the GraphQL API, are fundamentally backend management tools. Their placement in the `graphql` module could cause confusion or misinterpretation about their purpose and usage. By moving them to a `backend` module, we clarify their roles and streamline the architecture of the crate.

Moreover, exposing `Config` publicly aligns with Rust's guidelines on API transparency and usability, allowing users to interact with and configure our tools more effectively.
