### PR TITLE
Add IP-based access control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   accessible.
 - Added session limitation based on the `max_parallel_sessions` field of `Account`
   during sign-in.
+- Added ip access control based on the `allow_access_from` field of `Account`
+  during sign-in.
 
 ### Changed
 
@@ -23,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   newly created `backend` module. This change better organizes the code
   structure by separating concerns, as these traits are not directly related to
   the GraphQL API but are instead utilized within it.
+- Update `TestSchema` to accept `test_addr` for simulating client IP.
 
 ### Fixed
 

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -1155,7 +1155,7 @@ mod tests {
             send_result_checker,
         });
 
-        let schema = TestSchema::new_with(agent_manager).await;
+        let schema = TestSchema::new_with(agent_manager, None).await;
 
         // node_shutdown
         let res = schema
@@ -1185,7 +1185,7 @@ mod tests {
             send_result_checker,
         });
 
-        let schema = TestSchema::new_with(agent_manager).await;
+        let schema = TestSchema::new_with(agent_manager, None).await;
 
         // check empty
         let res = schema.execute(r#"{nodeList{totalCount}}"#).await;

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -352,7 +352,7 @@ mod tests {
             online_apps_by_host_id,
         });
 
-        let schema = TestSchema::new_with(agent_manager).await;
+        let schema = TestSchema::new_with(agent_manager, None).await;
 
         // check empty
         let res = schema.execute(r#"{nodeList{totalCount}}"#).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,9 +202,12 @@ async fn graphql_handler(
         }
         Err(_e) => {
             if is_local(addr) {
-                Ok(schema.execute(request.data(RoleGuard::Local)).await.into())
+                Ok(schema
+                    .execute(request.data(RoleGuard::Local).data(addr))
+                    .await
+                    .into())
             } else {
-                Ok(schema.execute(request).await.into())
+                Ok(schema.execute(request.data(addr)).await.into())
             }
         }
     }


### PR DESCRIPTION
- Update `graphql_handler` to include client IP in requests.
- Modify `signIn` to validate IP against `allowAccessFrom`.
- Update `TestSchema` to accept `test_addr` for simulating client IP.

Close: #39