### PR TITLE
Modify the NodeSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     - `cargo fmt -- --check --config group_imports=StdExternalCrate`
 - Updated version of rustls to "0.23" and fixed related code due to reqwest
   version update.
+- Modified the `NodeSettings` fields.
+  - The new `protocols` and `sensors` field should be sorted in alphabetical order.
+- The `get_node_settings` function returns a `Result<Vec<Setting>>`, with the
+  following fields set to `None`:
+  - `Setting::{piglet, reconverge, hog}::rpc`
+  - `Setting::reconverge::public`
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "78ff219" }
-review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.3.0" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "b60d4d3" }
+review-protocol = { git = "https://github.com/petabi/review-protocol.git", rev = "4a6ea44" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.23" #should be the same version as what reqwest depends on
 rustls-native-certs = "0.7"

--- a/src/graphql/node/input.rs
+++ b/src/graphql/node/input.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::IpAddr};
+use std::net::IpAddr;
 
 use anyhow::Context as AnyhowContext;
 use async_graphql::{types::ID, InputObject, Result};
@@ -13,22 +13,16 @@ pub struct NodeSettingsInput {
     pub description: String,
     pub hostname: String,
 
-    pub review: bool,
-    pub review_port: Option<PortNumber>,
-    pub review_web_port: Option<PortNumber>,
-
     pub piglet: bool,
     pub piglet_giganto_ip: Option<String>,
     pub piglet_giganto_port: Option<PortNumber>,
-    pub piglet_review_ip: Option<String>,
-    pub piglet_review_port: Option<PortNumber>,
     pub save_packets: bool,
     pub http: bool,
     pub office: bool,
     pub exe: bool,
     pub pdf: bool,
-    pub html: bool,
     pub txt: bool,
+    pub vbs: bool,
     pub smtp_eml: bool,
     pub ftp: bool,
 
@@ -42,20 +36,12 @@ pub struct NodeSettingsInput {
     pub retention_period: Option<u16>,
 
     pub reconverge: bool,
-    pub reconverge_review_ip: Option<String>,
-    pub reconverge_review_port: Option<PortNumber>,
-    pub reconverge_giganto_ip: Option<String>,
-    pub reconverge_giganto_port: Option<PortNumber>,
 
     pub hog: bool,
-    pub hog_review_ip: Option<String>,
-    pub hog_review_port: Option<PortNumber>,
     pub hog_giganto_ip: Option<String>,
     pub hog_giganto_port: Option<PortNumber>,
-    pub protocols: bool,
-    pub protocol_list: HashMap<String, bool>,
-    pub sensors: bool,
-    pub sensor_list: HashMap<String, bool>,
+    pub protocols: Option<Vec<String>>,
+    pub sensors: Option<Vec<String>>,
 }
 
 impl TryFrom<NodeSettingsInput> for review_database::NodeSettings {
@@ -66,21 +52,16 @@ impl TryFrom<NodeSettingsInput> for review_database::NodeSettings {
             customer_id: input.customer_id.parse().context("invalid customer ID")?,
             description: input.description.clone(),
             hostname: input.hostname.clone(),
-            review: input.review,
-            review_port: input.review_port,
-            review_web_port: input.review_web_port,
             piglet: input.piglet,
             piglet_giganto_ip: parse_str_to_ip(input.piglet_giganto_ip.as_deref()),
             piglet_giganto_port: input.piglet_giganto_port,
-            piglet_review_ip: parse_str_to_ip(input.piglet_review_ip.as_deref()),
-            piglet_review_port: input.piglet_review_port,
             save_packets: input.save_packets,
             http: input.http,
             office: input.office,
             exe: input.exe,
             pdf: input.pdf,
-            html: input.html,
             txt: input.txt,
+            vbs: input.vbs,
             smtp_eml: input.smtp_eml,
             ftp: input.ftp,
             giganto: input.giganto,
@@ -92,19 +73,11 @@ impl TryFrom<NodeSettingsInput> for review_database::NodeSettings {
             giganto_graphql_port: input.giganto_graphql_port,
             retention_period: input.retention_period,
             reconverge: input.reconverge,
-            reconverge_review_ip: parse_str_to_ip(input.reconverge_review_ip.as_deref()),
-            reconverge_review_port: input.reconverge_review_port,
-            reconverge_giganto_ip: parse_str_to_ip(input.reconverge_giganto_ip.as_deref()),
-            reconverge_giganto_port: input.reconverge_giganto_port,
             hog: input.hog,
-            hog_review_ip: parse_str_to_ip(input.hog_review_ip.as_deref()),
-            hog_review_port: input.hog_review_port,
             hog_giganto_ip: parse_str_to_ip(input.hog_giganto_ip.as_deref()),
             hog_giganto_port: input.hog_giganto_port,
             protocols: input.protocols,
-            protocol_list: input.protocol_list.clone(),
             sensors: input.sensors,
-            sensor_list: input.sensor_list.clone(),
         })
     }
 }

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -91,7 +91,6 @@ async fn load(
             used_disk_space,
             ping,
             piglet_config,
-            reconverge_config,
             hog_config,
         ) = match ev.settings.as_ref().map(|settings| &settings.hostname) {
             Some(hostname) => {
@@ -129,20 +128,6 @@ async fn load(
                         .and_then(|cfg| match cfg {
                             review_protocol::types::Config::Piglet(piglet_config) => {
                                 Some(piglet_config.into())
-                            }
-                            _ => None,
-                        })
-                } else {
-                    None
-                };
-                let reconverge_config = if let Some(true) = reconverge {
-                    agents
-                        .get_config(hostname, ModuleName::Reconverge.as_ref())
-                        .await
-                        .ok()
-                        .and_then(|cfg| match cfg {
-                            review_protocol::types::Config::Reconverge(reconverge_config) => {
-                                Some(reconverge_config.into())
                             }
                             _ => None,
                         })
@@ -205,12 +190,11 @@ async fn load(
                     used_disk_space,
                     ping,
                     piglet_config,
-                    reconverge_config,
                     hog_config,
                 )
             }
             None => (
-                None, None, None, None, None, None, None, None, None, None, None, None, None,
+                None, None, None, None, None, None, None, None, None, None, None, None,
             ),
         };
         connection.edges.push(Edge::new(
@@ -228,7 +212,6 @@ async fn load(
                 piglet,
                 piglet_config,
                 reconverge,
-                reconverge_config,
                 hog,
                 hog_config,
             ),
@@ -371,30 +354,23 @@ mod tests {
                         customerId: 0,
                         description: "This is the admin node running review.",
                         hostname: "host1",
-                        review: true,
-                        reviewPort: 1111,
-                        reviewWebPort: 1112,
                         piglet: true,
                         pigletGigantoIp: "0.0.0.0",
                         pigletGigantoPort: 5555,
-                        pigletReviewIp: "0.0.0.0",
-                        pigletReviewPort: 1111,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
                         reconverge: false,
                         hog: false,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                     )
                 }"#,
             )
@@ -424,32 +400,23 @@ mod tests {
                         customerId: 0,
                         description: "This is the reconverge, hog node.",
                         hostname: "host2",
-                        review: false,
                         piglet: false,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
-                        reconverge: true,
-                        reconvergeReviewIp: "0.0.0.0",
-                        reconvergeReviewPort: 1111,
-                        reconvergeGigantoIp: "0.0.0.0",
-                        reconvergeGigantoPort: 5555,
+                        reconverge: false,
                         hog: true,
-                        hogReviewIp: "0.0.0.0",
-                        hogReviewPort: 1111,
                         hogGigantoIp: "0.0.0.0",
                         hogGigantoPort: 5555,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                     )
                 }"#,
             )
@@ -468,7 +435,7 @@ mod tests {
             .await;
         assert_eq!(
             res.data.to_string(),
-            r#"{applyNode: {id: "1", successModules: [HOG, RECONVERGE]}}"#
+            r#"{applyNode: {id: "1", successModules: [HOG]}}"#
         );
 
         // check node status list
@@ -490,22 +457,12 @@ mod tests {
                             pigletConfig {
                                 gigantoIp
                                 gigantoPort
-                                reviewIp
-                                reviewPort
                             }
                             reconverge
-                            reconvergeConfig {
-                                gigantoIp
-                                gigantoPort
-                                reviewIp
-                                reviewPort
-                            }
                             hog
                             hogConfig {
                                 gigantoIp
                                 gigantoPort
-                                reviewIp
-                                reviewPort
                             }
                         }
                       }
@@ -531,7 +488,6 @@ mod tests {
                                 "piglet": true,
                                 "pigletConfig": null,
                                 "reconverge": false,
-                                "reconvergeConfig": null,
                                 "hog": false,
                                 "hogConfig": null,
                             }
@@ -549,7 +505,6 @@ mod tests {
                                 "piglet": false,
                                 "pigletConfig": null,
                                 "reconverge": true,
-                                "reconvergeConfig": null,
                                 "hog": true,
                                 "hogConfig": null,
                             }
@@ -573,21 +528,16 @@ mod tests {
                         customerId: 0,
                         description: "This is the admin node running review.",
                         hostname: "admin.aice-security.com",
-                        review: true,
-                        reviewPort: 1111,
-                        reviewWebPort: 1112,
                         piglet: false,
                         pigletGigantoIp: null,
                         pigletGigantoPort: null,
-                        pigletReviewIp: null,
-                        pigletReviewPort: null,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
@@ -599,19 +549,11 @@ mod tests {
                         gigantoGraphqlPort: null,
                         retentionPeriod: null,
                         reconverge: false,
-                        reconvergeReviewIp: null,
-                        reconvergeReviewPort: null,
-                        reconvergeGigantoIp: null,
-                        reconvergeGigantoPort: null,
                         hog: false,
-                        hogReviewIp: null,
-                        hogReviewPort: null,
                         hogGigantoIp: null,
                         hogGigantoPort: null,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                     )
                 }"#,
             )
@@ -626,21 +568,16 @@ mod tests {
                         customerId: 0,
                         description: "This is the admin node running review.",
                         hostname: "admin.aice-security.com",
-                        review: true,
-                        reviewPort: 1111,
-                        reviewWebPort: 1112,
                         piglet: false,
                         pigletGigantoIp: null,
                         pigletGigantoPort: null,
-                        pigletReviewIp: null,
-                        pigletReviewPort: null,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
@@ -652,19 +589,11 @@ mod tests {
                         gigantoGraphqlPort: null,
                         retentionPeriod: null,
                         reconverge: false,
-                        reconvergeReviewIp: null,
-                        reconvergeReviewPort: null,
-                        reconvergeGigantoIp: null,
-                        reconvergeGigantoPort: null,
                         hog: false,
-                        hogReviewIp: null,
-                        hogReviewPort: null,
                         hogGigantoIp: null,
                         hogGigantoPort: null,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                     )
                 }"#,
             )
@@ -679,21 +608,16 @@ mod tests {
                         customerId: 0,
                         description: "This is the admin node running review.",
                         hostname: "admin.aice-security.com",
-                        review: true,
-                        reviewPort: 1111,
-                        reviewWebPort: 1112,
                         piglet: false,
                         pigletGigantoIp: null,
                         pigletGigantoPort: null,
-                        pigletReviewIp: null,
-                        pigletReviewPort: null,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
@@ -705,19 +629,11 @@ mod tests {
                         gigantoGraphqlPort: null,
                         retentionPeriod: null,
                         reconverge: false,
-                        reconvergeReviewIp: null,
-                        reconvergeReviewPort: null,
-                        reconvergeGigantoIp: null,
-                        reconvergeGigantoPort: null,
                         hog: false,
-                        hogReviewIp: null,
-                        hogReviewPort: null,
                         hogGigantoIp: null,
                         hogGigantoPort: null,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                     )
                 }"#,
             )
@@ -732,21 +648,16 @@ mod tests {
                         customerId: 0,
                         description: "This is the admin node running review.",
                         hostname: "admin.aice-security.com",
-                        review: true,
-                        reviewPort: 1111,
-                        reviewWebPort: 1112,
                         piglet: false,
                         pigletGigantoIp: null,
                         pigletGigantoPort: null,
-                        pigletReviewIp: null,
-                        pigletReviewPort: null,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
@@ -758,19 +669,11 @@ mod tests {
                         gigantoGraphqlPort: null,
                         retentionPeriod: null,
                         reconverge: false,
-                        reconvergeReviewIp: null,
-                        reconvergeReviewPort: null,
-                        reconvergeGigantoIp: null,
-                        reconvergeGigantoPort: null,
                         hog: false,
-                        hogReviewIp: null,
-                        hogReviewPort: null,
                         hogGigantoIp: null,
                         hogGigantoPort: null,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                         )
                     }"#,
             )
@@ -785,21 +688,16 @@ mod tests {
                         customerId: 0,
                         description: "This is the admin node running review.",
                         hostname: "admin.aice-security.com",
-                        review: true,
-                        reviewPort: 1111,
-                        reviewWebPort: 1112,
                         piglet: false,
                         pigletGigantoIp: null,
                         pigletGigantoPort: null,
-                        pigletReviewIp: null,
-                        pigletReviewPort: null,
                         savePackets: false,
                         http: false,
                         office: false,
                         exe: false,
                         pdf: false,
-                        html: false,
                         txt: false,
+                        vbs: false,
                         smtpEml: false,
                         ftp: false,
                         giganto: false,
@@ -811,19 +709,11 @@ mod tests {
                         gigantoGraphqlPort: null,
                         retentionPeriod: null,
                         reconverge: false,
-                        reconvergeReviewIp: null,
-                        reconvergeReviewPort: null,
-                        reconvergeGigantoIp: null,
-                        reconvergeGigantoPort: null,
                         hog: false,
-                        hogReviewIp: null,
-                        hogReviewPort: null,
                         hogGigantoIp: null,
                         hogGigantoPort: null,
-                        protocols: false,
-                        protocolList: {},
-                        sensors: false,
-                        sensorList: {},
+                        protocols: null,
+                        sensors: null,
                     )
             }"#,
             )

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -438,7 +438,7 @@ mod tests {
     use crate::graphql::TestSchema;
 
     #[tokio::test]
-    async fn test_samplig_policy() {
+    async fn test_sampling_policy() {
         let schema = TestSchema::new().await;
 
         let res = schema.execute(r#"{samplingPolicyList{totalCount}}"#).await;


### PR DESCRIPTION
Cargo.toml의 review-database, review-protocol 버전 확인 필요

- Removed central server's address fields.
    - Removed `reconverge_giganto_[ip|port]` fields.
    - Removed `html` field.
    - Added `vbs` field.
    - Merged `protocols` (boolean) and `protocol_list` (`HashMap<String, bool>`) into
    `protocols: Option<Vec<String>>`.
    - The new `protocols` field should be sorted in alphabetical order.
  - Merged `sensors` (boolean) and `sensor_list` (`HashMap<String, bool>`) into
    `sensors: Option<Vec<String>>`.
    - The new `sensors` field should also be sorted in alphabetical order.
  - The `get_node_settings` function will be removed in the future.
    - Until it is removed, each `Setting` element returned by `get_node_settings`
      in `Result<Vec<Setting>>` will have the following fields always set to `0.0.0.0:0`.
      - `piglet.rpc`
      - `reconverge.rpc`
      - `reconverge.public`
      - `hog.rpc`
- Fix clippy error

Closes: https://github.com/aicers/review-web/issues/224
Closes: https://github.com/aicers/review-web/issues/225
Closes: https://github.com/aicers/review-web/issues/234