### PR TITLE
Modify related APIs due to addition of language field in Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Refactor `AgentManager::ping` to return `Duration` instead of `i64`. This
   refactor improves the flexibility and accuracy of the `ping` method, making it
   more robust and aligned with Rust's time handling conventions.
+- Added a `language` field to the `Account`. Consequently, the `account` and
+  `accountList` API responses now include this field. The `insertAccount` and
+  `updateAccount` GraphQL API endpoints are also updated to support the field.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.29.1" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "66ccdd49" }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", rev = "4a6ea44" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.23" #should be the same version as what reqwest depends on


### PR DESCRIPTION
Close: https://github.com/aicers/review-web/issues/250

Among the list of tasks I needed to perform was the following items.
- Modify account, insert_account, modify_account, and other related APIs in review-web as needed to support the field.
- Add two new APIs in review-web: one for retrieving the user's language setting, and another for updating it.

However, after looking at the existing code, I found that the original purpose could be achieved just by modifying the existing API rather than adding new APIs, so I worked on adding language-related codes to the existing function without adding separate new APIs. But, I think there could be some misunderstanding about these task so before I open the PR to merge, I have just opened the draft PR and I ask you to review the code I worked on. @sehkone 