### PR TITLE
Refactor `AgentManager::ping` to return `Duration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - In `BlockListSmb`, `Network`, `SamplingPolicy`, `Tidb`, and `TidbRule`,
   changed GraphQL APIs to return `StringNumber` or `ID` instead of integers
   beyond `i32`.
+- Refactor `AgentManager::ping` to return `Duration` instead of `i64`. This
+  refactor improves the flexibility and accuracy of the `ping` method, making it
+  more robust and aligned with Rust's time handling conventions.
 
 ### Fixed
 

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
     process::exit,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use anyhow::{anyhow, bail, Context, Error, Result};
@@ -118,7 +119,7 @@ impl AgentManager for Manager {
         bail!("Host {hostname} is unreachable")
     }
 
-    async fn ping(&self, hostname: &str) -> Result<i64, Error> {
+    async fn ping(&self, hostname: &str) -> Result<Duration, Error> {
         bail!("Host {hostname} is unreachable")
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -55,8 +55,8 @@ pub trait AgentManager: Send + Sync {
     async fn halt(&self, _hostname: &str) -> Result<(), anyhow::Error>;
 
     /// Sends a ping message to the given host and waits for a response. Returns
-    /// the round-trip time in microseconds.
-    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error>;
+    /// the round-trip time.
+    async fn ping(&self, _hostname: &str) -> Result<Duration, anyhow::Error>;
 
     /// Reboots the node with the given hostname.
     async fn reboot(&self, _hostname: &str) -> Result<(), anyhow::Error>;

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -577,7 +577,7 @@ impl AgentManager for MockAgentManager {
         unimplemented!()
     }
 
-    async fn ping(&self, _hostname: &str) -> Result<i64, anyhow::Error> {
+    async fn ping(&self, _hostname: &str) -> Result<std::time::Duration, anyhow::Error> {
         unimplemented!()
     }
 

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -232,7 +232,7 @@ async fn broadcast_customer_change(customer_id: u32, ctx: &Context<'_>) -> Resul
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use assert_json_diff::assert_json_eq;
     use async_trait::async_trait;
@@ -661,7 +661,7 @@ mod tests {
             Ok(())
         }
 
-        async fn ping(&self, hostname: &str) -> Result<i64, anyhow::Error> {
+        async fn ping(&self, hostname: &str) -> Result<Duration, anyhow::Error> {
             anyhow::bail!("{hostname} is unreachable")
         }
 


### PR DESCRIPTION
This refactor improves the flexibility and accuracy of the `ping` method, making it more robust and aligned with Rust's time handling conventions.

Resolves #274.