### PR TITLE
Use `f64` for `ping` field in `NodeStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Refactor `AgentManager::ping` to return `Duration` instead of `i64`. This
   refactor improves the flexibility and accuracy of the `ping` method, making it
   more robust and aligned with Rust's time handling conventions.
+- In the GraphQL API, modified the `ping` field in `NodeStatus` to return a
+  `Float` (seconds) instead of a `StringNumber` (microseconds). This provides a
+  more standard representation of round-trip time and improves compatibility
+  with GraphQL clients.
 
 ### Fixed
 

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -7,6 +7,7 @@ mod status;
 use std::{
     borrow::Cow,
     net::{IpAddr, SocketAddr},
+    time::Duration,
 };
 
 use async_graphql::{
@@ -328,9 +329,9 @@ pub(super) struct NodeStatus {
     #[graphql(skip)]
     used_disk_space: Option<u64>,
 
-    /// The ping value for a specific node.
+    /// The round-trip time to the node.
     #[graphql(skip)]
-    ping: Option<i64>,
+    ping: Option<Duration>,
 
     /// Whether review is online or not.
     review: Option<bool>,
@@ -372,9 +373,9 @@ impl NodeStatus {
     async fn used_disk_space(&self) -> Option<StringNumber<u64>> {
         self.used_disk_space.map(StringNumber)
     }
-    /// The round-trip time in microseconds to a host, within the range representable by an `i64`
-    async fn ping(&self) -> Option<StringNumber<i64>> {
-        self.ping.map(StringNumber)
+    /// The round-trip time to the node in seconds.
+    async fn ping(&self) -> Option<f64> {
+        self.ping.map(|d| d.as_secs_f64())
     }
 }
 
@@ -388,7 +389,7 @@ impl NodeStatus {
         used_memory: Option<u64>,
         total_disk_space: Option<u64>,
         used_disk_space: Option<u64>,
-        ping: Option<i64>,
+        ping: Option<Duration>,
         review: Option<bool>,
         piglet: Option<bool>,
         piglet_config: Option<PigletConfig>,

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -47,7 +47,7 @@ async fn load(
     let agents = ctx.data::<BoxedAgentManager>()?;
     let apps = agents.online_apps_by_host_id().await?;
     let mut usages: HashMap<String, ResourceUsage> = HashMap::new();
-    let mut ping: HashMap<String, i64> = HashMap::new();
+    let mut ping = HashMap::new();
     for hostname in apps.keys() {
         if let Ok(usage) = agents.get_resource_usage(hostname).await {
             usages.insert(
@@ -62,9 +62,7 @@ async fn load(
             );
         }
         if let Ok(rtt) = agents.ping(hostname).await {
-            let clamped_micros = i64::try_from(std::cmp::min(rtt.as_micros(), i64::MAX as u128))
-                .expect("within i64 range");
-            ping.insert(hostname.clone(), clamped_micros);
+            ping.insert(hostname.clone(), rtt);
         }
     }
 
@@ -473,7 +471,7 @@ mod tests {
                                 "usedMemory": "100",
                                 "totalDiskSpace": "1000",
                                 "usedDiskSpace": "100",
-                                "ping": "10",
+                                "ping": 0.00001,
                                 "review": true,
                                 "piglet": true,
                                 "pigletConfig": null,
@@ -490,7 +488,7 @@ mod tests {
                                 "usedMemory": "100",
                                 "totalDiskSpace": "1000",
                                 "usedDiskSpace": "100",
-                                "ping": "10",
+                                "ping": 0.00001,
                                 "review": false,
                                 "piglet": false,
                                 "pigletConfig": null,


### PR DESCRIPTION
This PR changes the `ping` field in `NodeStatus` in GraphQL API from `StringNumber`, a custom scalar type, to `Float`, a built-in scalar type.

Resolves #282.