### PR TITLE
Add the functions to get and update user's language setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   configurations.
 - Added new detected events:
   - `BlockListBootp`, `BlockListDhcp`, `SuspiciousTlsTraffic`
+- Added the `language` GraphQL API to get the user's UI language selection, and
+  the `updateLanguage` GraphQL API to modify it.
 
 ### Changed
 


### PR DESCRIPTION
Close: #268 

I added two APIs(functions) in this work. One is a function that takes username as a parameter and returns the language of the corresponding account(L422~L425 in `account.rs`), and the other is a function that takes username as a parameter and modifies the language of the corresponding account. 

~~However, while writing the test code, I found that if we ask for account query, we can get the value of the language field. I wasn't sure if we really need the first function.~~

I thought maybe I was misunderstanding the work I was assigned. So I opened work on #268 issue with draft PR. I would sincerely appreciate it if you could comment on my work, and if there is anything I misunderstood, I will immediately correct it and continue the work. @sophie-cluml  @sehkone 