### PR TITLE
Fix CHANGELOG entry for `ping` in GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   refactor improves the flexibility and accuracy of the `ping` method, making it
   more robust and aligned with Rust's time handling conventions.
 - In the GraphQL API, modified the `ping` field in `NodeStatus` to return a
-  `Float` (seconds) instead of a `StringNumber` (microseconds). This provides a
-  more standard representation of round-trip time and improves compatibility
-  with GraphQL clients.
+  `Float` (seconds) instead of a `Int` (microseconds). This change improves
+  precision when converting the internal representation of the `ping` field to
+  a GraphQL-compatible type.
 - Added a `language` field to the `Account`. Consequently, the `account` and
   `accountList` API responses now include this field. The `insertAccount` and
   `updateAccount` GraphQL API endpoints are also updated to support the field.


### PR DESCRIPTION
The entry in CHANGELOG should describe the change against the last release. This commit fixes the entry for the `ping` field in the GraphQL API so that it is compared against the last release rather than the last commit before the change.

This corrects #283, which has resolved #282. Documentation change only.