### PR TITLE
Add category field to TI db and rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added a `language` field to the `Account`. Consequently, the `account` and
   `accountList` API responses now include this field. The `insertAccount` and
   `updateAccount` GraphQL API endpoints are also updated to support the field.
+- Added `category` field to TI db and rules.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "66ccdd49" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "2eda8f9" }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", rev = "4a6ea44" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.23" #should be the same version as what reqwest depends on

--- a/src/graphql/tidb.rs
+++ b/src/graphql/tidb.rs
@@ -1,7 +1,7 @@
 use async_graphql::{Context, Enum, Object, Result, SimpleObject, ID};
 use review_database::{self as database};
 
-use super::{Role, RoleGuard};
+use super::{triage::ThreatCategory, Role, RoleGuard};
 
 #[derive(Default)]
 pub(super) struct TidbQuery;
@@ -154,6 +154,11 @@ impl Tidb {
         self.inner.kind.into()
     }
 
+    /// The MITRE category of the Tidb.
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
+    }
+
     /// The version of the Tidb.
     async fn version(&self) -> &str {
         &self.inner.version
@@ -188,6 +193,10 @@ struct TidbRule {
 impl TidbRule {
     async fn rule_id(&self) -> ID {
         ID(self.inner.rule_id.to_string())
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn name(&self) -> &str {
@@ -247,7 +256,7 @@ mod tests {
     async fn isud_tidb() {
         let schema = TestSchema::new().await;
 
-        let query_tidblist = r#"{tidbList{name,version}}"#;
+        let query_tidblist = r#"{tidbList{name,version,category}}"#;
         let res = schema.execute(query_tidblist).await;
         assert_eq!(res.data.to_string(), r#"{tidbList: []}"#);
     }


### PR DESCRIPTION
Close #294 

Add `category` field to TI db and rules.

I divided the PR #255 into smaller pieces because its too large change. This is the first PR.