### PR TITLE
Insert category field to the detected event fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `accountList` API responses now include this field. The `insertAccount` and
   `updateAccount` GraphQL API endpoints are also updated to support the field.
 - Added `category` field to TI db and rules.
+- Added `category` fields to all the the detected events.
+- Added new fields to `TorConnection` event.
+  - `orig_filenames`, `orig_mime_types`, `resp_filenames`, `resp_mime_types`,
+    `post_body`, `state`
+- Added new fields to `BlockListConn` event.
+  - `orig_l2_bytes`, `resp_l2_bytes`
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "2eda8f9" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "72c2cf2" }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", rev = "4a6ea44" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = "0.23" #should be the same version as what reqwest depends on

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -46,15 +46,27 @@ use tracing::{error, warn};
 
 pub(super) use self::group::EventGroupQuery;
 use self::{
-    conn::BlockListConn, conn::ExternalDdos, conn::MultiHostPortScan, conn::PortScan,
-    dcerpc::BlockListDceRpc, dns::BlockListDns, dns::CryptocurrencyMiningPool,
-    dns::DnsCovertChannel, dns::LockyRansomware, ftp::BlockListFtp, ftp::FtpBruteForce,
-    ftp::FtpPlainText, http::BlockListHttp, http::DomainGenerationAlgorithm, http::HttpThreat,
-    http::NonBrowser, http::RepeatedHttpSessions, http::TorConnection, kerberos::BlockListKerberos,
-    ldap::BlockListLdap, ldap::LdapBruteForce, ldap::LdapPlainText, log::ExtraThreat,
-    mqtt::BlockListMqtt, network::NetworkThreat, nfs::BlockListNfs, ntlm::BlockListNtlm,
-    rdp::BlockListRdp, rdp::RdpBruteForce, smb::BlockListSmb, smtp::BlockListSmtp,
-    ssh::BlockListSsh, sysmon::WindowsThreat, tls::BlockListTls,
+    conn::{BlockListConn, ExternalDdos, MultiHostPortScan, PortScan},
+    dcerpc::BlockListDceRpc,
+    dns::{BlockListDns, CryptocurrencyMiningPool, DnsCovertChannel, LockyRansomware},
+    ftp::{BlockListFtp, FtpBruteForce, FtpPlainText},
+    http::{
+        BlockListHttp, DomainGenerationAlgorithm, HttpThreat, NonBrowser, RepeatedHttpSessions,
+        TorConnection,
+    },
+    kerberos::BlockListKerberos,
+    ldap::{BlockListLdap, LdapBruteForce, LdapPlainText},
+    log::ExtraThreat,
+    mqtt::BlockListMqtt,
+    network::NetworkThreat,
+    nfs::BlockListNfs,
+    ntlm::BlockListNtlm,
+    rdp::{BlockListRdp, RdpBruteForce},
+    smb::BlockListSmb,
+    smtp::BlockListSmtp,
+    ssh::BlockListSsh,
+    sysmon::WindowsThreat,
+    tls::BlockListTls,
 };
 use super::{
     customer::{Customer, HostNetworkGroupInput},
@@ -1131,7 +1143,7 @@ mod tests {
 
     use chrono::{DateTime, NaiveDate, Utc};
     use futures_util::StreamExt;
-    use review_database::{event::DnsEventFields, EventKind, EventMessage};
+    use review_database::{event::DnsEventFields, EventCategory, EventKind, EventMessage};
 
     use crate::graphql::TestSchema;
 
@@ -1159,6 +1171,7 @@ mod tests {
             ra_flag: false,
             ttl: Vec::new(),
             confidence: 0.8,
+            category: EventCategory::CommandAndControl,
         };
         EventMessage {
             time: timestamp,
@@ -1656,6 +1669,7 @@ mod tests {
             ra_flag: false,
             ttl: Vec::new(),
             confidence: 0.8,
+            category: EventCategory::CommandAndControl,
         };
         let message = EventMessage {
             time: timestamp,

--- a/src/graphql/event/conn.rs
+++ b/src/graphql/event/conn.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct PortScan {
@@ -76,6 +76,10 @@ impl PortScan {
 
     async fn last_time(&self) -> DateTime<Utc> {
         self.inner.last_time
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -183,6 +187,10 @@ impl MultiHostPortScan {
         self.inner.last_time
     }
 
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
+    }
+
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
         self.inner
             .triage_scores
@@ -282,6 +290,10 @@ impl ExternalDdos {
 
     async fn last_time(&self) -> DateTime<Utc> {
         self.inner.last_time
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -396,6 +408,18 @@ impl BlockListConn {
 
     async fn resp_pkts(&self) -> StringNumber<u64> {
         StringNumber(self.inner.resp_pkts)
+    }
+
+    async fn orig_l2_bytes(&self) -> StringNumber<u64> {
+        StringNumber(self.inner.orig_l2_bytes)
+    }
+
+    async fn resp_l2_bytes(&self) -> StringNumber<u64> {
+        StringNumber(self.inner.resp_l2_bytes)
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/dcerpc.rs
+++ b/src/graphql/event/dcerpc.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListDceRpc {
     inner: database::BlockListDceRpc,
@@ -95,6 +95,10 @@ impl BlockListDceRpc {
 
     async fn operation(&self) -> &str {
         &self.inner.endpoint
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/dns.rs
+++ b/src/graphql/event/dns.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct DnsCovertChannel {
@@ -132,6 +132,10 @@ impl DnsCovertChannel {
 
     async fn confidence(&self) -> f32 {
         self.inner.confidence
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -277,6 +281,10 @@ impl LockyRansomware {
         self.inner.confidence
     }
 
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
+    }
+
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
         self.inner
             .triage_scores
@@ -413,6 +421,10 @@ impl CryptocurrencyMiningPool {
 
     async fn coins(&self) -> Vec<String> {
         self.inner.coins.clone()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -553,6 +565,9 @@ impl BlockListDns {
         self.inner.ttl.clone()
     }
 
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
+    }
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
         self.inner
             .triage_scores

--- a/src/graphql/event/ftp.rs
+++ b/src/graphql/event/ftp.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct FtpBruteForce {
@@ -84,6 +84,10 @@ impl FtpBruteForce {
 
     async fn is_internal(&self) -> bool {
         self.inner.is_internal
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -219,6 +223,10 @@ impl FtpPlainText {
 
     async fn file_id(&self) -> &str {
         &self.inner.file_id
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -358,6 +366,10 @@ impl BlockListFtp {
 
     async fn file_id(&self) -> &str {
         &self.inner.file_id
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/group.rs
+++ b/src/graphql/event/group.rs
@@ -437,7 +437,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use chrono::{DateTime, NaiveDate, Utc};
-    use review_database::{event::DnsEventFields, EventKind, EventMessage};
+    use review_database::{event::DnsEventFields, EventCategory, EventKind, EventMessage};
 
     use crate::graphql::TestSchema;
 
@@ -465,6 +465,7 @@ mod tests {
             ra_flag: false,
             ttl: Vec::new(),
             confidence: 0.8,
+            category: EventCategory::CommandAndControl,
         };
         EventMessage {
             time: timestamp,

--- a/src/graphql/event/http.rs
+++ b/src/graphql/event/http.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct HttpThreat {
@@ -210,6 +210,10 @@ impl HttpThreat {
         self.inner.confidence
     }
 
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
+    }
+
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
         self.inner
             .triage_scores
@@ -294,6 +298,10 @@ impl RepeatedHttpSessions {
         let store = crate::graphql::get_store(ctx).await?;
         let map = store.network_map();
         find_ip_network(&map, self.inner.dst_addr)
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -452,6 +460,34 @@ impl TorConnection {
 
     async fn cache_control(&self) -> &str {
         &self.inner.cache_control
+    }
+
+    async fn orig_filenames(&self) -> Vec<String> {
+        self.inner.orig_filenames.clone()
+    }
+
+    async fn orig_mime_types(&self) -> Vec<String> {
+        self.inner.orig_mime_types.clone()
+    }
+
+    async fn resp_filenames(&self) -> Vec<String> {
+        self.inner.resp_filenames.clone()
+    }
+
+    async fn resp_mime_types(&self) -> Vec<String> {
+        self.inner.resp_mime_types.clone()
+    }
+
+    async fn post_body(&self) -> Vec<u8> {
+        self.inner.post_body.clone()
+    }
+
+    async fn state(&self) -> &str {
+        &self.inner.state
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -636,6 +672,10 @@ impl DomainGenerationAlgorithm {
         self.inner.confidence
     }
 
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
+    }
+
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
         self.inner
             .triage_scores
@@ -812,6 +852,10 @@ impl NonBrowser {
 
     async fn state(&self) -> &str {
         &self.inner.state
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -996,6 +1040,10 @@ impl BlockListHttp {
 
     async fn state(&self) -> &str {
         &self.inner.state
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/kerberos.rs
+++ b/src/graphql/event/kerberos.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListKerberos {
     inner: database::BlockListKerberos,
@@ -123,6 +123,10 @@ impl BlockListKerberos {
 
     async fn service_name(&self) -> Vec<String> {
         self.inner.service_name.clone()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/ldap.rs
+++ b/src/graphql/event/ldap.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct LdapBruteForce {
@@ -84,6 +84,10 @@ impl LdapBruteForce {
 
     async fn last_time(&self) -> DateTime<Utc> {
         self.inner.last_time
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -201,6 +205,10 @@ impl LdapPlainText {
 
     async fn argument(&self) -> Vec<String> {
         self.inner.argument.clone()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -323,6 +331,10 @@ impl BlockListLdap {
 
     async fn argument(&self) -> Vec<String> {
         self.inner.argument.clone()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/log.rs
+++ b/src/graphql/event/log.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::TriageScore;
+use crate::graphql::triage::ThreatCategory;
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct ExtraThreat {
@@ -53,6 +54,10 @@ impl ExtraThreat {
 
     async fn confidence(&self) -> f32 {
         self.inner.confidence
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/mqtt.rs
+++ b/src/graphql/event/mqtt.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListMqtt {
     inner: database::BlockListMqtt,
@@ -103,6 +103,10 @@ impl BlockListMqtt {
 
     async fn suback_reason(&self) -> Vec<u8> {
         self.inner.suback_reason.clone()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/network.rs
+++ b/src/graphql/event/network.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct NetworkThreat {
@@ -112,6 +112,10 @@ impl NetworkThreat {
 
     async fn confidence(&self) -> f32 {
         self.inner.confidence
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/nfs.rs
+++ b/src/graphql/event/nfs.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListNfs {
     inner: database::BlockListNfs,
@@ -87,6 +87,10 @@ impl BlockListNfs {
 
     async fn write_files(&self) -> Vec<String> {
         self.inner.write_files.clone()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/ntlm.rs
+++ b/src/graphql/event/ntlm.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListNtlm {
     inner: database::BlockListNtlm,
@@ -99,6 +99,10 @@ impl BlockListNtlm {
 
     async fn success(&self) -> &str {
         &self.inner.success
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/rdp.rs
+++ b/src/graphql/event/rdp.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct RdpBruteForce {
@@ -78,6 +78,10 @@ impl RdpBruteForce {
         let store = crate::graphql::get_store(ctx).await?;
         let map = store.network_map();
         find_ip_network(&map, self.inner.src_addr)
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {
@@ -172,6 +176,10 @@ impl BlockListRdp {
 
     async fn cookie(&self) -> String {
         self.inner.cookie.to_string()
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/smb.rs
+++ b/src/graphql/event/smb.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListSmb {
     inner: database::BlockListSmb,
@@ -123,6 +123,10 @@ impl BlockListSmb {
 
     async fn change_time(&self) -> i64 {
         self.inner.change_time
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/smtp.rs
+++ b/src/graphql/event/smtp.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListSmtp {
     inner: database::BlockListSmtp,
@@ -107,6 +107,10 @@ impl BlockListSmtp {
 
     async fn state(&self) -> &str {
         &self.inner.state
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/ssh.rs
+++ b/src/graphql/event/ssh.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListSsh {
     inner: database::BlockListSsh,
@@ -131,6 +131,10 @@ impl BlockListSsh {
 
     async fn server_shka(&self) -> &str {
         &self.inner.server_shka
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/sysmon.rs
+++ b/src/graphql/event/sysmon.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::TriageScore;
+use crate::graphql::triage::ThreatCategory;
 
 #[allow(clippy::module_name_repetitions)]
 pub(super) struct WindowsThreat {
@@ -73,6 +74,10 @@ impl WindowsThreat {
 
     async fn confidence(&self) -> f32 {
         self.inner.confidence
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {

--- a/src/graphql/event/tls.rs
+++ b/src/graphql/event/tls.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use review_database as database;
 
 use super::{country_code, find_ip_customer, find_ip_network, TriageScore};
-use crate::graphql::{customer::Customer, network::Network};
+use crate::graphql::{customer::Customer, network::Network, triage::ThreatCategory};
 
 pub(super) struct BlockListTls {
     inner: database::BlockListTls,
@@ -163,6 +163,10 @@ impl BlockListTls {
 
     async fn last_alert(&self) -> u8 {
         self.inner.last_alert
+    }
+
+    async fn category(&self) -> ThreatCategory {
+        self.inner.category.into()
     }
 
     async fn triage_scores(&self) -> Option<Vec<TriageScore>> {


### PR DESCRIPTION
Close #244 

- Add `category` field to all the detected events
- Add new fields to `TorConnection` event.
  - `orig_filenames`, `orig_mime_types`, `resp_filenames`, `resp_mime_types`,
    `post_body`, `state`
- Add new fields to `BlockListConn` event.
  - `orig_l2_bytes`, `resp_l2_bytes`

I divided the PR #255 into smaller pieces because its too large change. This is the second PR.