### PR TITLE
Simplify `topClustersByScore` implementation

### DIFF
--- a/src/graphql/model.rs
+++ b/src/graphql/model.rs
@@ -136,30 +136,24 @@ impl ModelQuery {
         Ok(time_series)
     }
 
+    #[allow(unused_variables)] // This will be deleted in the future (#309)
     #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
         .or(RoleGuard::new(Role::SecurityAdministrator))
         .or(RoleGuard::new(Role::SecurityManager))
         .or(RoleGuard::new(Role::SecurityMonitor))")]
     async fn top_clusters_by_score(
         &self,
-        ctx: &Context<'_>,
+        _ctx: &Context<'_>,
         model: i32,
         size: Option<i32>,
         time: Option<NaiveDateTime>,
     ) -> Result<ClusterScoreSet> {
-        const DEFAULT_SIZE: i32 = 30;
-        let size = size
-            .unwrap_or(DEFAULT_SIZE)
-            .to_usize()
-            .ok_or("invalid size")?;
-        let db = ctx.data::<Database>()?;
-        let types = db.get_column_types_of_model(model).await?;
-
-        let db = ctx.data::<Database>()?;
-        let inner = db
-            .get_top_clusters_by_score(model, size, time, &types)
-            .await?;
-        Ok(ClusterScoreSet { inner })
+        Ok(ClusterScoreSet {
+            inner: database::ClusterScoreSet {
+                top_n_sum: Vec::new(),
+                top_n_rate: Vec::new(),
+            },
+        })
     }
 
     #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)


### PR DESCRIPTION
This PR simplifies the `topClustersByScore` implementation in the GraphQL API by removing the call to `Database::get_top_clusters_by_score`, which always returns an empty set. Instead, we directly return an empty `ClusterScoreSet`, reducing unnecessary calls and preventing future compile errors when `review-database` is updated to version 0.31.

### Context:
- Issue [#309](https://github.com/aicers/review-web/issues/309) proposes deleting the `topClustersByScore` API, as it no longer provides meaningful data.
- The underlying implementation depends on the `csv_indicator` table in the database, which is no longer populated (refer to [petabi/review-database#341](https://github.com/petabi/review-database/issues/341)).
- The table and the API itself are slated for deletion in review-database 0.31.0.

This change simplifies the current implementation, in line with the future deletion of the API.