### PR TITLE
Correct heading level in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 
 - Fixed an issue in the `applyNode` GraphQL API where agents could not be
   properly identified.


### PR DESCRIPTION
I noticed that the heading level in our CHANGELOG was a bit off. This tiny PR bumps the `Fixed` section from H2 (`##`) to H3 (`###`) to keep our hierarchy consistent.