### PR TITLE
Update review-database to 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated review-database to 0.31.0.
+
 ### Fixed
 
 - Fixed an issue in the `applyNode` GraphQL API where agents could not be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 
 - Fixed an issue in the `applyNode` GraphQL API where agents could not be
   properly identified.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.30.0" }
+review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.31.0" }
 review-protocol = { git = "https://github.com/petabi/review-protocol.git", tag = "0.6.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.2.1" }
 rustls = { version = "0.23", default-features = false, features = [

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -325,7 +325,8 @@ where
         Connection::with_additional_fields(has_previous, has_next, additional_fields);
     connection.edges.extend(nodes.into_iter().map(|node| {
         let Ok(node) = node else { unreachable!() };
-        Edge::new(encode_cursor(&node.unique_key()), node.into())
+        let encoded = encode_cursor(node.unique_key().as_ref());
+        Edge::new(encoded, node.into())
     }));
     Ok(connection)
 }
@@ -351,7 +352,7 @@ where
         };
         let mut edges: Box<dyn Iterator<Item = _>> = Box::new(iter.skip_while(move |item| {
             if let Ok(x) = item {
-                x.unique_key() == cursor
+                x.unique_key().as_ref() == cursor.as_slice()
             } else {
                 false
             }

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -78,7 +78,7 @@ async fn load(
             .collect();
 
         connection.edges.push(Edge::new(
-            crate::graphql::encode_cursor(&node.unique_key()),
+            crate::graphql::encode_cursor(node.unique_key()),
             NodeStatus::new(
                 node.id,
                 node.name,

--- a/src/graphql/outlier.rs
+++ b/src/graphql/outlier.rs
@@ -100,7 +100,7 @@ async fn fetch_ranked_outliers(
                 if is_first_fetch && entry.timestamp < start_time {
                     continue;
                 }
-                model_cursor = entry.unique_key().to_vec();
+                model_cursor = entry.unique_key();
                 tx.unbounded_send(entry.into())?;
             }
             if !model_cursor.is_empty() {
@@ -516,7 +516,7 @@ async fn load(
             has_more = true;
             break;
         }
-        let key = entry.unique_key().to_vec();
+        let key = entry.unique_key();
         if let Some(to) = to {
             if key == to {
                 break;
@@ -642,7 +642,7 @@ async fn load_ranked_outliers_with_filter(
         let key = node.unique_key();
 
         if let Some(to) = to {
-            if to == key.as_ref() {
+            if to == key {
                 continue;
             }
         }


### PR DESCRIPTION
This PR updates review-database to version 0.31.0, which includes a bug fix that's crucial for our application at @petabi. We'd greatly appreciate it if this update could be included in the next release of review-web.

The changes in this PR are minimal, only adapting to the API change in review-database, and shouldn't introduce any functional changes. 

Note that this PR is built on top of the changes in #318, so it's best to review and merge that one first to avoid any conflicts.