### PR TITLE
Make the GraphQL APIs check the pagination params in the same manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   instead of its serialized form. This change decouples review-web from
   dictating the serialized form of `HostNetworkGroup`, which should be handled
   by the review-protocol crate.
+- Instead of `async_graphql::connection::query`, its wrapper `graphql::query` is
+  now used for all GraphQL APIs to support pagination.
+  - The GraphQL APIs `clusters`, `eventList`, and `models` were changed to no
+    longer accept invalid pagination parameters, such as providing both `after`
+    and `before`, by using `graphql::query`.
+
+### Fixed
+
+- Fixed `savedOutliers` and `rankedOutliers` to properly validate pagination
+  parameters.
 
 ## [0.22.0] - 2024-10-04
 

--- a/src/graphql/account.rs
+++ b/src/graphql/account.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::anyhow;
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, Enum, InputObject, Object, Result, SimpleObject, StringNumber,
 };
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
@@ -19,6 +19,7 @@ use tracing::info;
 
 use super::RoleGuard;
 use crate::auth::{create_token, decode_token, insert_token, revoke_token, update_jwt_expires_in};
+use crate::graphql::query;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Serialize, SimpleObject)]

--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -1,5 +1,5 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
 };
 use database::Direction;
@@ -10,6 +10,7 @@ use super::{
     customer::{HostNetworkGroup, HostNetworkGroupInput},
     BoxedAgentManager, Role, RoleGuard,
 };
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct AllowNetworkQuery;

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
 };
 use database::Direction;
@@ -13,6 +13,7 @@ use super::{
     customer::{HostNetworkGroup, HostNetworkGroupInput},
     BoxedAgentManager, Role, RoleGuard,
 };
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct BlockNetworkQuery;

--- a/src/graphql/category.rs
+++ b/src/graphql/category.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Object, Result,
 };
@@ -10,6 +10,7 @@ use review_database::{self as database};
 use tokio::sync::RwLock;
 
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct CategoryQuery;

--- a/src/graphql/cluster.rs
+++ b/src/graphql/cluster.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{query, Connection, Edge, EmptyFields},
+    connection::{Connection, Edge, EmptyFields},
     types::ID,
     ComplexObject, Context, Object, Result, SimpleObject, StringNumber,
 };
@@ -21,6 +21,7 @@ use super::{
     status::Status,
     Role, RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
 };
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct ClusterQuery;

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 
 use anyhow::Context as AnyhowContext;
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Enum, InputObject, Object, Result, SimpleObject,
 };
@@ -11,6 +11,7 @@ use review_database::{self as database, Store};
 use tracing::error;
 
 use super::{get_customer_id_of_node, BoxedAgentManager, Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct CustomerQuery;

--- a/src/graphql/data_source.rs
+++ b/src/graphql/data_source.rs
@@ -1,11 +1,12 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Enum, InputObject, Object, Result,
 };
 use review_database::{self as database};
 
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct DataSourceQuery;

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -29,7 +29,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context as AnyhowContext};
 use async_graphql::{
-    connection::{query, Connection, Edge, EmptyFields},
+    connection::{Connection, Edge, EmptyFields},
     Context, InputObject, Object, Result, Subscription, Union, ID,
 };
 use chrono::{DateTime, Utc};
@@ -78,6 +78,7 @@ use super::{
     network::Network,
     Role, RoleGuard,
 };
+use crate::graphql::query;
 
 const DEFAULT_CONNECTION_SIZE: usize = 100;
 const DEFAULT_EVENT_FETCH_TIME: u64 = 20;

--- a/src/graphql/model.rs
+++ b/src/graphql/model.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{query, Connection, Edge, EmptyFields},
+    connection::{Connection, Edge, EmptyFields},
     types::ID,
     Context, Object, Result, SimpleObject, StringNumber,
 };
@@ -15,6 +15,7 @@ use super::{
     cluster::TimeCount, data_source::DataSource, fill_vacant_time_slots, get_trend, slicing, Role,
     RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
 };
+use crate::graphql::query;
 
 const DEFAULT_MIN_SLOPE: f64 = 10.0;
 const DEFAULT_MIN_ZERO_COUNT_FOR_TREND: u32 = 5;

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryInto, mem::size_of};
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, InputObject, Object, Result,
 };
@@ -12,6 +12,7 @@ use super::{
     customer::{Customer, HostNetworkGroup, HostNetworkGroupInput},
     Role, RoleGuard,
 };
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct NetworkQuery;

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::fn_params_excessive_bools)]
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Object, Result,
 };
@@ -14,7 +14,7 @@ use super::{
     input::{AgentInput, GigantoInput, NodeDraftInput},
     Node, NodeInput, NodeMutation, NodeQuery, NodeTotalCount,
 };
-use crate::graphql::{customer::broadcast_customer_networks, get_customer_networks};
+use crate::graphql::{customer::broadcast_customer_networks, get_customer_networks, query};
 
 #[Object]
 impl NodeQuery {

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use async_graphql::{
-    connection::{query, Connection, Edge, EmptyFields},
+    connection::{Connection, Edge, EmptyFields},
     Context, Object, Result,
 };
 use review_database::UniqueKey;
@@ -11,6 +11,7 @@ use super::{
     super::{BoxedAgentManager, Role, RoleGuard},
     matches_manager_hostname, NodeStatus, NodeStatusQuery, NodeStatusTotalCount,
 };
+use crate::graphql::query;
 
 #[Object]
 impl NodeStatusQuery {

--- a/src/graphql/qualifier.rs
+++ b/src/graphql/qualifier.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Object, Result,
 };
@@ -10,6 +10,7 @@ use review_database::{self as database};
 use tokio::sync::RwLock;
 
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct QualifierQuery;

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Enum, InputObject, Object, Result, StringNumber,
 };
@@ -10,6 +10,7 @@ use review_database::{Direction, Iterable};
 use serde::{Deserialize, Serialize};
 
 use super::{BoxedAgentManager, Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct SamplingPolicyQuery;

--- a/src/graphql/statistics.rs
+++ b/src/graphql/statistics.rs
@@ -1,5 +1,5 @@
 use async_graphql::{
-    connection::{query, Connection, ConnectionNameType, Edge, EmptyFields},
+    connection::{Connection, ConnectionNameType, Edge, EmptyFields},
     types::ID,
     Context, Object, Result, StringNumber,
 };
@@ -9,6 +9,7 @@ use review_database::{BatchInfo, Database};
 use serde_json::Value as JsonValue;
 
 use super::{slicing, Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct StatisticsQuery;

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, Object, Result,
 };
@@ -10,6 +10,7 @@ use review_database::{self as database};
 use tokio::sync::RwLock;
 
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct StatusQuery;

--- a/src/graphql/template.rs
+++ b/src/graphql/template.rs
@@ -1,12 +1,13 @@
 use std::convert::{TryFrom, TryInto};
 
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, Enum, InputObject, Object, Result, StringNumber, Union,
 };
 use serde::{Deserialize, Serialize};
 
 use super::{ParseEnumError, Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct TemplateQuery;

--- a/src/graphql/tor_exit_node.rs
+++ b/src/graphql/tor_exit_node.rs
@@ -1,11 +1,12 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
 };
 use chrono::{DateTime, Utc};
 use review_database::{Direction, Iterable};
 
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct TorExitNodeQuery;

--- a/src/graphql/triage/policy.rs
+++ b/src/graphql/triage/policy.rs
@@ -1,5 +1,5 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, Object, Result, ID,
 };
 use chrono::Utc;
@@ -10,6 +10,7 @@ use super::{
     TriagePolicyMutation, TriagePolicyQuery,
 };
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 struct TriagePolicyTotalCount;
 

--- a/src/graphql/triage/response.rs
+++ b/src/graphql/triage/response.rs
@@ -1,11 +1,12 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     types::ID,
     Context, InputObject, Object, Result,
 };
 use chrono::{DateTime, Utc};
 
 use super::{Role, RoleGuard};
+use crate::graphql::query;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct TriageResponse {

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -1,9 +1,10 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
 };
 
 use super::{AgentManager, BoxedAgentManager, Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct TrustedDomainQuery;

--- a/src/graphql/trusted_user_agent.rs
+++ b/src/graphql/trusted_user_agent.rs
@@ -1,5 +1,5 @@
 use async_graphql::{
-    connection::{query, Connection, EmptyFields},
+    connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
 };
 use bincode::Options;
@@ -8,6 +8,7 @@ use database::{Direction, Iterable};
 use review_database::{self as database, Store};
 
 use super::{BoxedAgentManager, Role, RoleGuard};
+use crate::graphql::query;
 
 #[derive(Default)]
 pub(super) struct UserAgentQuery;


### PR DESCRIPTION
Closes #323 

In addition to #323, I refactored the code to eliminate repetition and renamed `load_nodes` in graphql.rs to `load_edges_interim` for clarity.
