### PR TITLE
Decouple `AgentManager` from serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Modified the `AgentManager` trait to accept `HostNetworkGroup` directly
+  instead of its serialized form. This change decouples review-web from
+  dictating the serialized form of `HostNetworkGroup`, which should be handled
+  by the review-protocol crate.
+
 ## [0.22.0] - 2024-10-04
 
 ### Added
@@ -674,6 +683,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - An initial version.
 
+[Unreleased]: https://github.com/aicers/review-web/compare/0.22.0...main
 [0.22.0]: https://github.com/aicers/review-web/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/aicers/review-web/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/aicers/review-web/compare/0.19.0...0.20.0

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -16,7 +16,7 @@ use futures::{
     pin_mut,
 };
 use ipnet::IpNet;
-use review_database::{migrate_data_dir, Database, Store};
+use review_database::{migrate_data_dir, Database, HostNetworkGroup, Store};
 use review_web::{
     self as web,
     backend::{AgentManager, CertManager},
@@ -74,15 +74,24 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
-    async fn broadcast_internal_networks(&self, _networks: &[u8]) -> Result<Vec<String>, Error> {
+    async fn broadcast_internal_networks(
+        &self,
+        _networks: &HostNetworkGroup,
+    ) -> Result<Vec<String>, Error> {
         bail!("Not supported")
     }
 
-    async fn broadcast_allow_networks(&self, _networks: &[u8]) -> Result<Vec<String>, Error> {
+    async fn broadcast_allow_networks(
+        &self,
+        _networks: &HostNetworkGroup,
+    ) -> Result<Vec<String>, Error> {
         bail!("Not supported")
     }
 
-    async fn broadcast_block_networks(&self, _networks: &[u8]) -> Result<Vec<String>, Error> {
+    async fn broadcast_block_networks(
+        &self,
+        _networks: &HostNetworkGroup,
+    ) -> Result<Vec<String>, Error> {
         bail!("Not supported")
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, path::PathBuf, time::Duration};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use ipnet::IpNet;
+use review_database::HostNetworkGroup;
 pub use roxy::{Process, ResourceUsage};
 
 pub use crate::graphql::{ParsedCertificate, SamplingPolicy};
@@ -15,17 +16,17 @@ pub trait AgentManager: Send + Sync {
 
     async fn broadcast_internal_networks(
         &self,
-        _networks: &[u8],
+        networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error>;
 
     async fn broadcast_allow_networks(
         &self,
-        _networks: &[u8],
+        networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error>;
 
     async fn broadcast_block_networks(
         &self,
-        _networks: &[u8],
+        networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error>;
 
     async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -46,6 +46,8 @@ use async_graphql::{
 use chrono::TimeDelta;
 use data_encoding::BASE64;
 use num_traits::ToPrimitive;
+#[cfg(test)]
+use review_database::HostNetworkGroup;
 use review_database::{self as database, Database, Direction, Role, Store};
 pub use roxy::{Process, ResourceUsage};
 use tokio::sync::{Notify, RwLock};
@@ -529,19 +531,19 @@ impl AgentManager for MockAgentManager {
 
     async fn broadcast_internal_networks(
         &self,
-        _networks: &[u8],
+        _networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error> {
         Ok(vec!["hog@hostA".to_string()])
     }
     async fn broadcast_allow_networks(
         &self,
-        _networks: &[u8],
+        _networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error> {
         Ok(vec!["hog@hostA".to_string(), "hog@hostB".to_string()])
     }
     async fn broadcast_block_networks(
         &self,
-        _networks: &[u8],
+        _networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error> {
         Ok(vec![
             "hog@hostA".to_string(),

--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -2,7 +2,6 @@ use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
 };
-use bincode::Options;
 use database::Direction;
 use review_database::{self as database, Store};
 use serde::{Deserialize, Serialize};
@@ -124,11 +123,10 @@ impl AllowNetworkMutation {
     async fn apply_allow_networks(&self, ctx: &Context<'_>) -> Result<Vec<String>> {
         let store = crate::graphql::get_store(ctx).await?;
 
-        let serialized_networks =
-            bincode::DefaultOptions::new().serialize(&get_allow_networks(&store)?)?;
+        let networks = get_allow_networks(&store)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
-            .broadcast_allow_networks(&serialized_networks)
+            .broadcast_allow_networks(&networks)
             .await
             .map_err(Into::into)
     }

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -4,7 +4,6 @@ use async_graphql::{
     connection::{query, Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
 };
-use bincode::Options;
 use database::Direction;
 use review_database::{self as database, Store};
 use serde::{Deserialize, Serialize};
@@ -126,11 +125,10 @@ impl BlockNetworkMutation {
         .or(RoleGuard::new(Role::SecurityAdministrator))")]
     async fn apply_block_networks(&self, ctx: &Context<'_>) -> Result<Vec<String>> {
         let db = super::get_store(ctx).await?;
-        let serialized_networks =
-            bincode::DefaultOptions::new().serialize(&get_block_networks(&db)?)?;
+        let networks = get_block_networks(&db)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
-            .broadcast_block_networks(&serialized_networks)
+            .broadcast_block_networks(&networks)
             .await
             .map_err(Into::into)
     }

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -6,7 +6,6 @@ use async_graphql::{
     types::ID,
     Context, Enum, InputObject, Object, Result, SimpleObject,
 };
-use bincode::Options;
 use chrono::{DateTime, Utc};
 use review_database::{self as database, Store};
 use tracing::error;
@@ -493,10 +492,9 @@ pub async fn broadcast_customer_networks(
     ctx: &Context<'_>,
     networks: &database::HostNetworkGroup,
 ) -> Result<Vec<String>> {
-    let networks = bincode::DefaultOptions::new().serialize(&networks)?;
     let agent_manager = ctx.data::<BoxedAgentManager>()?;
     agent_manager
-        .broadcast_internal_networks(&networks)
+        .broadcast_internal_networks(networks)
         .await
         .map_err(Into::into)
 }

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -303,6 +303,7 @@ mod tests {
     use assert_json_diff::assert_json_eq;
     use async_trait::async_trait;
     use ipnet::IpNet;
+    use review_database::HostNetworkGroup;
     use serde_json::json;
 
     use crate::graphql::{AgentManager, BoxedAgentManager, SamplingPolicy, TestSchema};
@@ -1433,21 +1434,21 @@ mod tests {
         }
         async fn broadcast_internal_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             Ok(vec!["hog@hostA".to_string()])
         }
 
         async fn broadcast_allow_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             Ok(vec![])
         }
 
         async fn broadcast_block_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             Ok(vec![])
         }
@@ -1533,21 +1534,21 @@ mod tests {
         }
         async fn broadcast_internal_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             anyhow::bail!("Failed to broadcast internal networks")
         }
 
         async fn broadcast_allow_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             anyhow::bail!("Failed to broadcast allow networks")
         }
 
         async fn broadcast_block_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             anyhow::bail!("Failed to broadcast block networks")
         }

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -103,6 +103,7 @@ mod tests {
 
     use assert_json_diff::assert_json_include;
     use axum::async_trait;
+    use review_database::HostNetworkGroup;
     use roxy::ResourceUsage;
     use serde_json::json;
 
@@ -116,21 +117,21 @@ mod tests {
     impl AgentManager for MockAgentManager {
         async fn broadcast_internal_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             anyhow::bail!("not expected to be called")
         }
 
         async fn broadcast_allow_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             unimplemented!()
         }
 
         async fn broadcast_block_networks(
             &self,
-            _networks: &[u8],
+            _networks: &HostNetworkGroup,
         ) -> Result<Vec<String>, anyhow::Error> {
             unimplemented!()
         }


### PR DESCRIPTION
This PR modifies the methods in `AgentManager` trait to accept `HostNetworkGroup` directly instead of its serialized form. By doing so, we allow the review-protocol crate to handle serialization, which is a more suitable place for this responsibility.

This change is required for petabi/review-protocol#13.