### PR TITLE
Refactor code to avoid redundant query validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   instead of its serialized form. This change decouples review-web from
   dictating the serialized form of `HostNetworkGroup`, which should be handled
   by the review-protocol crate.
-- Instead of `async_graphql::connection::query`, its wrapper `graphql::query` is
-  now used for all GraphQL APIs to support pagination.
-  - The GraphQL APIs `clusters`, `eventList`, and `models` were changed to no
-    longer accept invalid pagination parameters, such as providing both `after`
-    and `before`, by using `graphql::query`.
 - The `applyNode` GraphQL API now accepts a `NodeInput` argument, in order to
   validate that the provided node data matches the current state in the database
   before applying changes.
+- The default connection size is no longer used. Instead, the maximum connection
+  size is applied if users don't specify a size.
 
 ### Fixed
 

--- a/src/graphql/account.rs
+++ b/src/graphql/account.rs
@@ -19,7 +19,7 @@ use tracing::info;
 
 use super::RoleGuard;
 use crate::auth::{create_token, decode_token, insert_token, revoke_token, update_jwt_expires_in};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Serialize, SimpleObject)]
@@ -59,7 +59,7 @@ impl AccountQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Account, AccountTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -10,7 +10,7 @@ use super::{
     customer::{HostNetworkGroup, HostNetworkGroupInput},
     BoxedAgentManager, Role, RoleGuard,
 };
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct AllowNetworkQuery;
@@ -30,7 +30,7 @@ impl AllowNetworkQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, AllowNetwork, AllowNetworkTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -13,7 +13,7 @@ use super::{
     customer::{HostNetworkGroup, HostNetworkGroupInput},
     BoxedAgentManager, Role, RoleGuard,
 };
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct BlockNetworkQuery;
@@ -33,7 +33,7 @@ impl BlockNetworkQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, BlockNetwork, BlockNetworkTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/category.rs
+++ b/src/graphql/category.rs
@@ -10,7 +10,7 @@ use review_database::{self as database};
 use tokio::sync::RwLock;
 
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct CategoryQuery;
@@ -30,7 +30,7 @@ impl CategoryQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Category, CategoryTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/cluster.rs
+++ b/src/graphql/cluster.rs
@@ -365,7 +365,7 @@ async fn load(
     let after = slicing::decode_cursor(&after)?;
     let before = slicing::decode_cursor(&before)?;
     let is_first = first.is_some();
-    let limit = slicing::limit(first, last)?;
+    let limit = slicing::len(first, last)?;
     let db = ctx.data::<Database>()?;
     let rows = db
         .load_clusters(

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -11,7 +11,7 @@ use review_database::{self as database, Store};
 use tracing::error;
 
 use super::{get_customer_id_of_node, BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct CustomerQuery;
@@ -29,7 +29,7 @@ impl CustomerQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Customer, CustomerTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/data_source.rs
+++ b/src/graphql/data_source.rs
@@ -6,7 +6,7 @@ use async_graphql::{
 use review_database::{self as database};
 
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct DataSourceQuery;
@@ -26,7 +26,7 @@ impl DataSourceQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, DataSource, DataSourceTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/model.rs
+++ b/src/graphql/model.rs
@@ -907,7 +907,7 @@ async fn load(
     let after = slicing::decode_cursor(&after)?;
     let before = slicing::decode_cursor(&before)?;
     let is_first = first.is_some();
-    let limit = slicing::limit(first, last)?;
+    let limit = slicing::len(first, last)?;
     let db = ctx.data::<Database>()?;
     let rows = db.load_models(&after, &before, is_first, limit).await?;
 

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -12,7 +12,7 @@ use super::{
     customer::{Customer, HostNetworkGroup, HostNetworkGroupInput},
     Role, RoleGuard,
 };
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct NetworkQuery;
@@ -32,7 +32,7 @@ impl NetworkQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Network, NetworkTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -14,7 +14,9 @@ use super::{
     input::{AgentInput, GigantoInput, NodeDraftInput},
     Node, NodeInput, NodeMutation, NodeQuery, NodeTotalCount,
 };
-use crate::graphql::{customer::broadcast_customer_networks, get_customer_networks, query};
+use crate::graphql::{
+    customer::broadcast_customer_networks, get_customer_networks, query_with_constraints,
+};
 
 #[Object]
 impl NodeQuery {
@@ -29,7 +31,7 @@ impl NodeQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Node, NodeTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -11,7 +11,7 @@ use super::{
     super::{BoxedAgentManager, Role, RoleGuard},
     matches_manager_hostname, NodeStatus, NodeStatusQuery, NodeStatusTotalCount,
 };
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[Object]
 impl NodeStatusQuery {
@@ -26,7 +26,7 @@ impl NodeStatusQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, NodeStatus, NodeStatusTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/qualifier.rs
+++ b/src/graphql/qualifier.rs
@@ -10,7 +10,7 @@ use review_database::{self as database};
 use tokio::sync::RwLock;
 
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct QualifierQuery;
@@ -30,7 +30,7 @@ impl QualifierQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Qualifier, QualifierTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -10,7 +10,7 @@ use review_database::{Direction, Iterable};
 use serde::{Deserialize, Serialize};
 
 use super::{BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct SamplingPolicyQuery;
@@ -240,7 +240,7 @@ impl SamplingPolicyQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, SamplingPolicy, SamplingPolicyTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/statistics.rs
+++ b/src/graphql/statistics.rs
@@ -9,7 +9,7 @@ use review_database::{BatchInfo, Database};
 use serde_json::Value as JsonValue;
 
 use super::{slicing, Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::{query, query_with_constraints};
 
 #[derive(Default)]
 pub(super) struct StatisticsQuery;
@@ -74,7 +74,7 @@ impl StatisticsQuery {
     ) -> Result<Connection<String, Round, TotalCountByModel, EmptyFields, RoundByModel>> {
         let model = model.as_str().parse()?;
 
-        query(
+        query_with_constraints(
             after,
             before,
             first,
@@ -157,7 +157,7 @@ async fn load_rounds_by_cluster(
     let after = slicing::decode_cursor(after)?.map(|(_, t)| i64_to_naive_date_time(t));
     let before = slicing::decode_cursor(before)?.map(|(_, t)| i64_to_naive_date_time(t));
     let is_first = first.is_some();
-    let limit = slicing::limit(first, last)?;
+    let limit = slicing::len(first, last)?;
     let db = ctx.data::<Database>()?;
     let (model, batches) = db
         .load_rounds_by_cluster(cluster, &after, &before, is_first, limit + 1)

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -10,7 +10,7 @@ use review_database::{self as database};
 use tokio::sync::RwLock;
 
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct StatusQuery;
@@ -30,7 +30,7 @@ impl StatusQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Status, StatusTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/template.rs
+++ b/src/graphql/template.rs
@@ -7,7 +7,7 @@ use async_graphql::{
 use serde::{Deserialize, Serialize};
 
 use super::{ParseEnumError, Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct TemplateQuery;
@@ -27,7 +27,7 @@ impl TemplateQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, Template, TemplateTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/tor_exit_node.rs
+++ b/src/graphql/tor_exit_node.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use review_database::{Direction, Iterable};
 
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct TorExitNodeQuery;
@@ -26,7 +26,7 @@ impl TorExitNodeQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TorExitNode, TorExitNodeTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/triage/policy.rs
+++ b/src/graphql/triage/policy.rs
@@ -10,7 +10,7 @@ use super::{
     TriagePolicyMutation, TriagePolicyQuery,
 };
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 struct TriagePolicyTotalCount;
 
@@ -36,7 +36,7 @@ impl TriagePolicyQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TriagePolicy, TriagePolicyTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/triage/response.rs
+++ b/src/graphql/triage/response.rs
@@ -6,7 +6,7 @@ use async_graphql::{
 use chrono::{DateTime, Utc};
 
 use super::{Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct TriageResponse {
@@ -74,7 +74,7 @@ impl super::TriageResponseQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TriageResponse, TriageResponseTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -4,7 +4,7 @@ use async_graphql::{
 };
 
 use super::{AgentManager, BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct TrustedDomainQuery;
@@ -24,7 +24,7 @@ impl TrustedDomainQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TrustedDomain, EmptyFields, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,

--- a/src/graphql/trusted_user_agent.rs
+++ b/src/graphql/trusted_user_agent.rs
@@ -8,7 +8,7 @@ use database::{Direction, Iterable};
 use review_database::{self as database, Store};
 
 use super::{BoxedAgentManager, Role, RoleGuard};
-use crate::graphql::query;
+use crate::graphql::query_with_constraints;
 
 #[derive(Default)]
 pub(super) struct UserAgentQuery;
@@ -28,7 +28,7 @@ impl UserAgentQuery {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<String, TrustedUserAgent, TrustedUserAgentTotalCount, EmptyFields>> {
-        query(
+        query_with_constraints(
             after,
             before,
             first,


### PR DESCRIPTION
Closes #328 

These two wrappers, `graphql::query` and `graphql::query_with_contraints` resolve the issue and revert the regression affecting several APIs, such as `clusters`.