### PR TITLE
Prevent agent notification if `draft` is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Modified `applyNode` GraphQL API logic to prevent notifying agents that are
+  operating with local configuration.
+
 ## [0.23.0] - 2024-10-23
 
 ### Changed
@@ -708,6 +715,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - An initial version.
 
+[Unreleased]: https://github.com/aicers/review-web/compare/0.23.0...main
 [0.23.0]: https://github.com/aicers/review-web/compare/0.22.0...0.23.0
 [0.22.0]: https://github.com/aicers/review-web/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/aicers/review-web/compare/0.20.0...0.21.0


### PR DESCRIPTION
closes: #332 