### PR TITLE
Fix sampling policy related APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `applyNode` GraphQL API logic to prevent notifying agents that are
   operating with local configuration.
 
+### Fixed
+
+- Added missing `node` field in `samplingPolicy` and `samplingPolicyList`
+  GraphQL API responses in the `SamplingPolicy` object.
+
 ## [0.23.0] - 2024-10-23
 
 ### Changed

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -1194,7 +1194,7 @@ mod tests {
     /// destination `IPv4` addresses.
     fn event_message_at(timestamp: DateTime<Utc>, src: u32, dst: u32) -> EventMessage {
         let fields = DnsEventFields {
-            source: "collector1".to_string(),
+            source: "sensor1".to_string(),
             session_end_time: timestamp,
             src_addr: Ipv4Addr::from(src).into(),
             src_port: 10000,
@@ -1292,10 +1292,10 @@ mod tests {
             .execute(
                 r#"mutation {
                     insertNode(
-                        name: "collector1",
+                        name: "sensor1",
                         customerId: 0,
-                        description: "This is the collector node",
-                        hostname: "collector1",
+                        description: "This is the sensor node",
+                        hostname: "sensor1",
                         agents: [{
                             key: "piglet"
                             kind: PIGLET
@@ -1313,13 +1313,13 @@ mod tests {
                     applyNode(
                         id: "0"
                         node: {
-                            name: "collector1",
-                            nameDraft: "collector1",
+                            name: "sensor1",
+                            nameDraft: "sensor1",
                             profile: null,
                             profileDraft: {
                                 customerId: 0,
-                                description: "This is the collector node",
-                                hostname: "collector1",
+                                description: "This is the sensor node",
+                                hostname: "sensor1",
                             }
                             agents: [
                                 {
@@ -1376,7 +1376,7 @@ mod tests {
         let res = schema.execute(&query).await;
         assert_eq!(
             res.data.to_string(),
-            r#"{eventList: {edges: [{node: {time: "2018-01-27T18:30:09.453829+00:00", source: "collector1"}}], totalCount: 1}}"#
+            r#"{eventList: {edges: [{node: {time: "2018-01-27T18:30:09.453829+00:00", source: "sensor1"}}], totalCount: 1}}"#
         );
     }
 
@@ -1708,7 +1708,7 @@ mod tests {
             .and_local_timezone(Utc)
             .unwrap();
         let fields = BlockListDhcpFields {
-            source: "collector1".to_string(),
+            source: "sensor1".to_string(),
             src_addr: Ipv4Addr::new(127, 0, 0, 1).into(),
             src_port: 68,
             dst_addr: Ipv4Addr::new(127, 0, 0, 2).into(),
@@ -1797,7 +1797,7 @@ mod tests {
             .and_local_timezone(Utc)
             .unwrap();
         let fields = BlockListBootpFields {
-            source: "collector1".to_string(),
+            source: "sensor1".to_string(),
             src_addr: Ipv4Addr::new(127, 0, 0, 1).into(),
             src_port: 68,
             dst_addr: Ipv4Addr::new(127, 0, 0, 2).into(),
@@ -1879,7 +1879,7 @@ mod tests {
             .and_local_timezone(Utc)
             .unwrap();
         let fields = DnsEventFields {
-            source: "collector1".to_string(),
+            source: "sensor1".to_string(),
             session_end_time: timestamp,
             src_addr: Ipv4Addr::from(1).into(),
             src_port: 10000,
@@ -1936,7 +1936,7 @@ mod tests {
             .and_local_timezone(Utc)
             .unwrap();
         let fields = BlockListTlsFields {
-            source: "collector1".to_string(),
+            source: "sensor1".to_string(),
             src_addr: Ipv4Addr::from(1).into(),
             src_port: 10000,
             dst_addr: Ipv4Addr::from(2).into(),

--- a/src/graphql/event/group.rs
+++ b/src/graphql/event/group.rs
@@ -445,7 +445,7 @@ mod tests {
     /// destination `IPv4` addresses.
     fn event_message_at(timestamp: DateTime<Utc>, src: u32, dst: u32) -> EventMessage {
         let fields = DnsEventFields {
-            source: "collector1".to_string(),
+            source: "sensor1".to_string(),
             session_end_time: timestamp,
             src_addr: Ipv4Addr::from(src).into(),
             src_port: 10000,


### PR DESCRIPTION
Close: #346 

Modified `samplingPolicy` and `samplingPolicyList` GraphQL API to have `node` field in their response.