### PR TITLE
Let async-graphql handle cursor encoding/decoding

### DIFF
--- a/src/graphql/model.rs
+++ b/src/graphql/model.rs
@@ -12,8 +12,11 @@ use review_database::{self as database, Database};
 use tokio::sync::RwLock;
 
 use super::{
-    cluster::TimeCount, data_source::DataSource, fill_vacant_time_slots, get_trend, slicing, Role,
-    RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
+    cluster::TimeCount,
+    data_source::DataSource,
+    fill_vacant_time_slots, get_trend,
+    slicing::{self, IndexedKey},
+    Role, RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
 };
 use crate::graphql::query;
 
@@ -37,7 +40,7 @@ impl ModelQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, ModelDigest, ModelTotalCount, EmptyFields>> {
+    ) -> Result<Connection<IndexedKey<String>, ModelDigest, ModelTotalCount, EmptyFields>> {
         query(
             after,
             before,
@@ -899,24 +902,29 @@ impl ModelTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<IndexedKey<String>>,
+    before: Option<IndexedKey<String>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, ModelDigest, ModelTotalCount, EmptyFields>> {
-    let after = slicing::decode_cursor(&after)?;
-    let before = slicing::decode_cursor(&before)?;
+) -> Result<Connection<IndexedKey<String>, ModelDigest, ModelTotalCount, EmptyFields>> {
     let is_first = first.is_some();
     let limit = slicing::len(first, last)?;
     let db = ctx.data::<Database>()?;
-    let rows = db.load_models(&after, &before, is_first, limit).await?;
+    let rows = db
+        .load_models(
+            &after.map(Into::into),
+            &before.map(Into::into),
+            is_first,
+            limit,
+        )
+        .await?;
 
     let (rows, has_previous, has_next) = slicing::page_info(is_first, limit, rows);
     let mut connection =
         Connection::with_additional_fields(has_previous, has_next, ModelTotalCount);
-    connection.edges.extend(rows.into_iter().map(|model| {
-        let cursor = slicing::encode_cursor(model.id, &model.name);
-        Edge::new(cursor, model.into())
-    }));
+    connection.edges.extend(
+        rows.into_iter()
+            .map(|model| Edge::new(IndexedKey::new(model.id, model.name.clone()), model.into())),
+    );
     Ok(connection)
 }

--- a/src/graphql/slicing.rs
+++ b/src/graphql/slicing.rs
@@ -1,31 +1,46 @@
 use std::{fmt, str::FromStr};
 
+use async_graphql::connection::CursorType;
 use data_encoding::BASE64;
 
 use super::Error;
 
-pub fn decode_cursor<T: FromStr>(cursor: &Option<String>) -> Result<Option<(i32, T)>, Error> {
-    match cursor.as_ref() {
-        Some(c) => {
-            let decoded = String::from_utf8(
-                BASE64
-                    .decode(c.as_bytes())
-                    .map_err(|_| Error::InvalidCursor)?,
-            )
-            .map_err(|_| Error::InvalidCursor)?;
-            let Some((id, value)) = decoded.split_once(':') else {
-                return Err(Error::InvalidCursor);
-            };
-            let id = id.parse().map_err(|_| Error::InvalidCursor)?;
-            let value = value.parse::<T>().map_err(|_| Error::InvalidCursor)?;
-            Ok(Some((id, value)))
-        }
-        None => Ok(None),
+pub(super) struct IndexedKey<T> {
+    pub(crate) id: i32,
+    pub(crate) value: T,
+}
+
+impl<T> IndexedKey<T> {
+    pub fn new(id: i32, value: T) -> Self {
+        Self { id, value }
     }
 }
 
-pub fn encode_cursor<T: fmt::Display>(id: i32, value: T) -> String {
-    BASE64.encode(format!("{id}:{value}").as_bytes())
+impl<T> From<IndexedKey<T>> for (i32, T) {
+    fn from(key: IndexedKey<T>) -> Self {
+        (key.id, key.value)
+    }
+}
+
+impl<T: FromStr + fmt::Display> CursorType for IndexedKey<T> {
+    type Error = super::Error;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        let decoded = String::from_utf8(
+            BASE64
+                .decode(s.as_bytes())
+                .map_err(|_| Error::InvalidCursor)?,
+        )
+        .map_err(|_| Error::InvalidCursor)?;
+        let (id, value) = decoded.split_once(':').ok_or(Error::InvalidCursor)?;
+        let id = id.parse().map_err(|_| Error::InvalidCursor)?;
+        let value = value.parse::<T>().map_err(|_| Error::InvalidCursor)?;
+        Ok(Self { id, value })
+    }
+
+    fn encode_cursor(&self) -> String {
+        BASE64.encode(format!("{}:{}", self.id, self.value).as_bytes())
+    }
 }
 
 // This internal method should be called after validating pagination paramerters by either


### PR DESCRIPTION
async-graphql's `query` function automatically handles cursor encoding and decoding. This commit removes the custom cursor encoding/decoding code from the `slicing` module and uses async-graphql's built-in functionality instead. This change only updates the `slicing` module to keep the PR minimal, and a follow-up change will be needed to address the top-level `encode_cursor` and `decode_cursor` functions in the `graphql` module.
