### PR TITLE
Update GraphQL cursor to use `OpaqueCursor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the encoding and decoding method for GraphQL cursors by removing
+  `graphql::encode_cursor` and `graphql::decode_cursor` methods and replacing
+  them with the encoding and decoding methods of `OpaqueCursor`.
+
 ### Fixed
 
 - Resolved an issue in the `applyNode` GraphQL API, where configuration values

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -48,7 +48,7 @@ impl Config {
 
     pub(crate) fn configure_reverse_proxies(
         store: &Arc<RwLock<Store>>,
-        client: &Option<reqwest::Client>,
+        client: Option<&reqwest::Client>,
         reverse_proxies: &[Self],
     ) -> Vec<(ArchiveState, Router<ArchiveState>)> {
         reverse_proxies
@@ -57,10 +57,10 @@ impl Config {
                 (
                     crate::archive::ArchiveState {
                         store: store.clone(),
-                        client: client.clone(),
+                        client: client.cloned(),
                         config: rp.clone(),
                     },
-                    crate::archive::reverse_proxy(store.clone(), client.clone(), rp.clone()),
+                    crate::archive::reverse_proxy(store.clone(), client.cloned(), rp.clone()),
                 )
             })
             .collect()

--- a/src/graphql/allow_network.rs
+++ b/src/graphql/allow_network.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
@@ -29,7 +30,8 @@ impl AllowNetworkQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, AllowNetwork, AllowNetworkTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, AllowNetwork, AllowNetworkTotalCount, EmptyFields>>
+    {
         query_with_constraints(
             after,
             before,
@@ -197,11 +199,11 @@ impl AllowNetworkTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, AllowNetwork, AllowNetworkTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, AllowNetwork, AllowNetworkTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.allow_network_map();
     super::load_edges(&map, after, before, first, last, AllowNetworkTotalCount)

--- a/src/graphql/block_network.rs
+++ b/src/graphql/block_network.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, InputObject, Object, Result, ID,
@@ -32,7 +33,8 @@ impl BlockNetworkQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, BlockNetwork, BlockNetworkTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, BlockNetwork, BlockNetworkTotalCount, EmptyFields>>
+    {
         query_with_constraints(
             after,
             before,
@@ -198,11 +200,11 @@ impl BlockNetworkTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, BlockNetwork, BlockNetworkTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, BlockNetwork, BlockNetworkTotalCount, EmptyFields>> {
     let db = super::get_store(ctx).await?;
     let map = db.block_network_map();
     super::load_edges(&map, after, before, first, last, BlockNetworkTotalCount)

--- a/src/graphql/category.rs
+++ b/src/graphql/category.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -29,7 +30,7 @@ impl CategoryQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Category, CategoryTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Category, CategoryTotalCount, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -108,11 +109,11 @@ impl CategoryTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Category, CategoryTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Category, CategoryTotalCount, EmptyFields>> {
     let store = super::get_store(ctx).await?;
     let table = store.category_map();
     super::load_edges(&table, after, before, first, last, CategoryTotalCount)

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -1,6 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use anyhow::Context as AnyhowContext;
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -28,7 +29,7 @@ impl CustomerQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Customer, CustomerTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Customer, CustomerTotalCount, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -459,11 +460,11 @@ impl CustomerTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Customer, CustomerTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Customer, CustomerTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.customer_map();
     super::load_edges(&map, after, before, first, last, CustomerTotalCount)
@@ -614,11 +615,11 @@ mod tests {
         );
 
         let res = schema
-            .execute(r#"{customerList(last: 10, before: "dDg="){edges{node{name}}totalCount,pageInfo{startCursor}}}"#)
+            .execute(r#"{customerList(last: 10, before: "WzExNiw1Nl0"){edges{node{name}}totalCount,pageInfo{startCursor}}}"#)
             .await;
         assert_eq!(
             res.data.to_string(),
-            r#"{customerList: {edges: [{node: {name: "t1"}}, {node: {name: "t10"}}, {node: {name: "t2"}}, {node: {name: "t3"}}, {node: {name: "t4"}}, {node: {name: "t5"}}, {node: {name: "t6"}}, {node: {name: "t7"}}], totalCount: 10, pageInfo: {startCursor: "dDE="}}}"#
+            r#"{customerList: {edges: [{node: {name: "t1"}}, {node: {name: "t10"}}, {node: {name: "t2"}}, {node: {name: "t3"}}, {node: {name: "t4"}}, {node: {name: "t5"}}, {node: {name: "t6"}}, {node: {name: "t7"}}], totalCount: 10, pageInfo: {startCursor: "WzExNiw0OV0"}}}"#
         );
 
         let res = schema
@@ -630,17 +631,17 @@ mod tests {
 
         let res = schema
             .execute(
-                r#"{customerList(first:10 after:"dDc=" ){edges{node{name}}totalCount,pageInfo{endCursor}}}"#,
+                r#"{customerList(first:10 after:"WzExNiw1NV0" ){edges{node{name}}totalCount,pageInfo{endCursor}}}"#,
             )
             .await;
         assert_eq!(
             res.data.to_string(),
-            r#"{customerList: {edges: [{node: {name: "t8"}}, {node: {name: "t9"}}], totalCount: 10, pageInfo: {endCursor: "dDk="}}}"#
+            r#"{customerList: {edges: [{node: {name: "t8"}}, {node: {name: "t9"}}], totalCount: 10, pageInfo: {endCursor: "WzExNiw1N10"}}}"#
         );
 
         let res = schema
         .execute(
-            r#"{customerList(first:10 before:"dDc=" ){edges{node{name}}totalCount,pageInfo{endCursor}}}"#,
+            r#"{customerList(first:10 before:"WzExNiw1NV0" ){edges{node{name}}totalCount,pageInfo{endCursor}}}"#,
         )
         .await;
         assert!(res.is_err());

--- a/src/graphql/data_source.rs
+++ b/src/graphql/data_source.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -25,7 +26,8 @@ impl DataSourceQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, DataSource, DataSourceTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, DataSource, DataSourceTotalCount, EmptyFields>>
+    {
         query_with_constraints(
             after,
             before,
@@ -259,11 +261,11 @@ impl DataSourceTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, DataSource, DataSourceTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, DataSource, DataSourceTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.data_source_map();
 

--- a/src/graphql/filter.rs
+++ b/src/graphql/filter.rs
@@ -476,12 +476,12 @@ impl PartialEq<FilterInput> for &database::Filter {
                 _ => false,
             }
             && self.keywords == rhs.keywords
-            && cmp_option_vec_string_with_id(&self.network_tags, &rhs.network_tags)
-            && cmp_option_vec_string_with_id(&self.customers, &rhs.customers)
+            && cmp_option_vec_string_with_id(self.network_tags.as_ref(), rhs.network_tags.as_ref())
+            && cmp_option_vec_string_with_id(self.customers.as_ref(), rhs.customers.as_ref())
             && network_eq
-            && cmp_option_vec_string_with_id(&self.sensors, &rhs.sensors)
-            && cmp_option_vec_string_with_id(&self.os, &rhs.os)
-            && cmp_option_vec_string_with_id(&self.devices, &rhs.devices)
+            && cmp_option_vec_string_with_id(self.sensors.as_ref(), rhs.sensors.as_ref())
+            && cmp_option_vec_string_with_id(self.os.as_ref(), rhs.os.as_ref())
+            && cmp_option_vec_string_with_id(self.devices.as_ref(), rhs.devices.as_ref())
             && self.host_names == rhs.host_names
             && self.user_ids == rhs.user_ids
             && self.user_names == rhs.user_names
@@ -546,7 +546,7 @@ pub(super) enum TrafficDirection {
     To,
 }
 
-fn cmp_option_vec_string_with_id(lhs: &Option<Vec<String>>, rhs: &Option<Vec<ID>>) -> bool {
+fn cmp_option_vec_string_with_id(lhs: Option<&Vec<String>>, rhs: Option<&Vec<ID>>) -> bool {
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => lhs
             .iter()

--- a/src/graphql/network.rs
+++ b/src/graphql/network.rs
@@ -1,5 +1,6 @@
 use std::{convert::TryInto, mem::size_of};
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -31,7 +32,7 @@ impl NetworkQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Network, NetworkTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Network, NetworkTotalCount, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -237,11 +238,11 @@ impl NetworkTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Network, NetworkTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Network, NetworkTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.network_map();
     super::load_edges(&map, after, before, first, last, NetworkTotalCount)

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -370,7 +370,7 @@ impl NodeStatus {
 impl NodeStatus {
     fn new(
         node: database::Node,
-        resource_usage: &Option<roxy::ResourceUsage>,
+        resource_usage: Option<&roxy::ResourceUsage>,
         ping: Option<Duration>,
         manager: bool,
     ) -> Self {

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::fn_params_excessive_bools)]
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -30,7 +31,7 @@ impl NodeQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Node, NodeTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Node, NodeTotalCount, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -159,11 +160,11 @@ impl NodeMutation {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Node, NodeTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Node, NodeTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.node_map();
     super::super::load_edges(&map, after, before, first, last, NodeTotalCount)

--- a/src/graphql/qualifier.rs
+++ b/src/graphql/qualifier.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -29,7 +30,8 @@ impl QualifierQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Qualifier, QualifierTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Qualifier, QualifierTotalCount, EmptyFields>>
+    {
         query_with_constraints(
             after,
             before,
@@ -105,11 +107,11 @@ impl QualifierTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Qualifier, QualifierTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Qualifier, QualifierTotalCount, EmptyFields>> {
     let store = super::get_store(ctx).await?;
     let table = store.qualifier_map();
     super::load_edges(&table, after, before, first, last, QualifierTotalCount)

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -1,5 +1,6 @@
 use std::net::IpAddr;
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -243,7 +244,9 @@ impl SamplingPolicyQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, SamplingPolicy, SamplingPolicyTotalCount, EmptyFields>> {
+    ) -> Result<
+        Connection<OpaqueCursor<Vec<u8>>, SamplingPolicy, SamplingPolicyTotalCount, EmptyFields>,
+    > {
         query_with_constraints(
             after,
             before,
@@ -271,11 +274,12 @@ impl SamplingPolicyQuery {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, SamplingPolicy, SamplingPolicyTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, SamplingPolicy, SamplingPolicyTotalCount, EmptyFields>>
+{
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.sampling_policy_map();
     super::load_edges(&map, after, before, first, last, SamplingPolicyTotalCount)

--- a/src/graphql/statistics.rs
+++ b/src/graphql/statistics.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, ConnectionNameType, Edge, EdgeNameType, EmptyFields},
     types::ID,
@@ -83,7 +84,9 @@ impl StatisticsQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Round, TotalCountByModel, EmptyFields, RoundByModel>> {
+    ) -> Result<
+        Connection<OpaqueCursor<Vec<u8>>, Round, TotalCountByModel, EmptyFields, RoundByModel>,
+    > {
         let model = model.as_str().parse()?;
 
         query_with_constraints(
@@ -227,11 +230,12 @@ async fn load_rounds_by_cluster(
 async fn load_rounds_by_model(
     ctx: &Context<'_>,
     model: i32,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Round, TotalCountByModel, EmptyFields, RoundByModel>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Round, TotalCountByModel, EmptyFields, RoundByModel>>
+{
     let store = super::get_store(ctx).await?;
     let table = store.batch_info_map();
     super::load_edges(

--- a/src/graphql/status.rs
+++ b/src/graphql/status.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -29,7 +30,7 @@ impl StatusQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Status, StatusTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Status, StatusTotalCount, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -105,11 +106,11 @@ impl StatusTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Status, StatusTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Status, StatusTotalCount, EmptyFields>> {
     let store = super::get_store(ctx).await?;
     let table = store.status_map();
     super::load_edges(&table, after, before, first, last, StatusTotalCount)

--- a/src/graphql/template.rs
+++ b/src/graphql/template.rs
@@ -1,5 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, Enum, InputObject, Object, Result, StringNumber, Union,
@@ -26,7 +27,7 @@ impl TemplateQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, Template, TemplateTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, Template, TemplateTotalCount, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -347,11 +348,11 @@ impl TemplateTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, Template, TemplateTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, Template, TemplateTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.template_map();
     super::load_edges(&map, after, before, first, last, TemplateTotalCount)

--- a/src/graphql/tor_exit_node.rs
+++ b/src/graphql/tor_exit_node.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
@@ -25,7 +26,8 @@ impl TorExitNodeQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, TorExitNode, TorExitNodeTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, TorExitNode, TorExitNodeTotalCount, EmptyFields>>
+    {
         query_with_constraints(
             after,
             before,
@@ -95,11 +97,11 @@ impl TorExitNodeTotalCount {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, TorExitNode, TorExitNodeTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, TorExitNode, TorExitNodeTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.tor_exit_node_map();
 

--- a/src/graphql/triage/policy.rs
+++ b/src/graphql/triage/policy.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, Object, Result, ID,
@@ -35,7 +36,8 @@ impl TriagePolicyQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, TriagePolicy, TriagePolicyTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, TriagePolicy, TriagePolicyTotalCount, EmptyFields>>
+    {
         query_with_constraints(
             after,
             before,
@@ -63,11 +65,11 @@ impl TriagePolicyQuery {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, TriagePolicy, TriagePolicyTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, TriagePolicy, TriagePolicyTotalCount, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.triage_policy_map();
     super::super::load_edges(&map, after, before, first, last, TriagePolicyTotalCount)

--- a/src/graphql/triage/response.rs
+++ b/src/graphql/triage/response.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     types::ID,
@@ -73,7 +74,9 @@ impl super::TriageResponseQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, TriageResponse, TriageResponseTotalCount, EmptyFields>> {
+    ) -> Result<
+        Connection<OpaqueCursor<Vec<u8>>, TriageResponse, TriageResponseTotalCount, EmptyFields>,
+    > {
         query_with_constraints(
             after,
             before,
@@ -101,11 +104,12 @@ impl super::TriageResponseQuery {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, TriageResponse, TriageResponseTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, TriageResponse, TriageResponseTotalCount, EmptyFields>>
+{
     let store = crate::graphql::get_store(ctx).await?;
     let table = store.triage_response_map();
     crate::graphql::load_edges(&table, after, before, first, last, TriageResponseTotalCount)

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
@@ -23,7 +24,7 @@ impl TrustedDomainQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, TrustedDomain, EmptyFields, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<Vec<u8>>, TrustedDomain, EmptyFields, EmptyFields>> {
         query_with_constraints(
             after,
             before,
@@ -96,11 +97,11 @@ impl From<review_database::TrustedDomain> for TrustedDomain {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, TrustedDomain, EmptyFields, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<Vec<u8>>, TrustedDomain, EmptyFields, EmptyFields>> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.trusted_domain_map();
     super::load_edges(&map, after, before, first, last, EmptyFields)

--- a/src/graphql/trusted_user_agent.rs
+++ b/src/graphql/trusted_user_agent.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::OpaqueCursor;
 use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
@@ -27,7 +28,14 @@ impl UserAgentQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<String, TrustedUserAgent, TrustedUserAgentTotalCount, EmptyFields>> {
+    ) -> Result<
+        Connection<
+            OpaqueCursor<Vec<u8>>,
+            TrustedUserAgent,
+            TrustedUserAgentTotalCount,
+            EmptyFields,
+        >,
+    > {
         query_with_constraints(
             after,
             before,
@@ -158,11 +166,13 @@ pub fn get_trusted_user_agent_list(db: &Store) -> Result<Vec<String>> {
 
 async fn load(
     ctx: &Context<'_>,
-    after: Option<String>,
-    before: Option<String>,
+    after: Option<OpaqueCursor<Vec<u8>>>,
+    before: Option<OpaqueCursor<Vec<u8>>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<String, TrustedUserAgent, TrustedUserAgentTotalCount, EmptyFields>> {
+) -> Result<
+    Connection<OpaqueCursor<Vec<u8>>, TrustedUserAgent, TrustedUserAgentTotalCount, EmptyFields>,
+> {
     let store = crate::graphql::get_store(ctx).await?;
     let map = store.trusted_user_agent_map();
     super::load_edges(&map, after, before, first, last, TrustedUserAgentTotalCount)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ where
 
             let proxies_config = crate::archive::Config::configure_reverse_proxies(
                 &store,
-                &client,
+                client.as_ref(),
                 &config.reverse_proxies,
             );
 


### PR DESCRIPTION
Close #355

The following sources are the main areas that have been modified.
graphql.rs
graphql directory sub-source

The rest of the changes are fixes for Clippy errors caused by the
Rust version update.