### PR TITLE
Replace custom cursor encoding with OpaqueCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Updated the encoding and decoding method for GraphQL cursors by removing
-  `graphql::encode_cursor` and `graphql::decode_cursor` methods and replacing
-  them with the encoding and decoding methods of `OpaqueCursor`.
+- The paginated GraphQL queries use different representations for cursors. The
+  cursor values obtained from earlier versions of the API are not compatible
+  with the new cursor values.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ bincode = "1"
 chrono = { version = ">=0.4.35", default-features = false, features = [
   "serde",
 ] }
-data-encoding = "2"
 futures = "0.3"
 futures-util = "0.3"
 http = "1"

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -270,8 +270,6 @@ where
 
 #[derive(Debug, thiserror::Error)]
 enum Error {
-    #[error("Invalid cursor")]
-    InvalidCursor,
     #[error("The value of first and last must be within 0-100")]
     InvalidLimitValue,
     #[error("You must provide a `first` or `last` value to properly paginate a connection.")]

--- a/src/graphql/cluster.rs
+++ b/src/graphql/cluster.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_graphql::{
-    connection::{Connection, Edge, EmptyFields},
+    connection::{Connection, Edge, EmptyFields, OpaqueCursor},
     types::ID,
     ComplexObject, Context, Object, Result, SimpleObject, StringNumber,
 };
@@ -17,7 +17,7 @@ use super::{
     get_trend,
     model::{ModelDigest, TopElementCountsByColumn},
     qualifier::Qualifier,
-    slicing::{self, IndexedKey},
+    slicing,
     status::Status,
     Role, RoleGuard, DEFAULT_CUTOFF_RATE, DEFAULT_TRENDI_ORDER,
 };
@@ -46,7 +46,7 @@ impl ClusterQuery {
         before: Option<String>,
         first: Option<i32>,
         last: Option<i32>,
-    ) -> Result<Connection<IndexedKey<i64>, Cluster, ClusterTotalCount, EmptyFields>> {
+    ) -> Result<Connection<OpaqueCursor<(i32, i64)>, Cluster, ClusterTotalCount, EmptyFields>> {
         let model = model.as_str().parse()?;
         let categories = try_id_args_into_ints(categories)?;
         let detectors = try_id_args_into_ints(detectors)?;
@@ -357,11 +357,11 @@ async fn load(
     detectors: Option<Vec<i32>>,
     qualifiers: Option<Vec<i32>>,
     statuses: Option<Vec<i32>>,
-    after: Option<IndexedKey<i64>>,
-    before: Option<IndexedKey<i64>>,
+    after: Option<OpaqueCursor<(i32, i64)>>,
+    before: Option<OpaqueCursor<(i32, i64)>>,
     first: Option<usize>,
     last: Option<usize>,
-) -> Result<Connection<IndexedKey<i64>, Cluster, ClusterTotalCount, EmptyFields>> {
+) -> Result<Connection<OpaqueCursor<(i32, i64)>, Cluster, ClusterTotalCount, EmptyFields>> {
     let is_first = first.is_some();
     let limit = slicing::len(first, last)?;
     let db = ctx.data::<Database>()?;
@@ -372,8 +372,8 @@ async fn load(
             detectors.as_deref(),
             qualifiers.as_deref(),
             statuses.as_deref(),
-            &after.map(Into::into),
-            &before.map(Into::into),
+            &after.map(|c| c.0),
+            &before.map(|c| c.0),
             is_first,
             limit,
         )
@@ -393,7 +393,7 @@ async fn load(
     );
     connection.edges.extend(rows.into_iter().map(|c| {
         Edge::new(
-            IndexedKey::new(c.id, c.size),
+            OpaqueCursor((c.id, c.size)),
             Cluster {
                 id: c.id,
                 name: c.cluster_id,


### PR DESCRIPTION
This replaces the custom cursor encoding and decoding logic with the `OpaqueCursor` type provided by `async-graphql`. This simplifies the code and reduces the risk of errors in cursor handling.

Note that this change breaks backwards compatibility with older versions of the GraphQL API, as the cursor format has changed.