### PR TITLE
Remove redundant std:: prefix from type names

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -82,7 +82,7 @@ impl ArchiveState {
 
 async fn auth(
     State(state): State<ArchiveState>,
-    bearer: std::result::Result<TypedHeader<Authorization<Bearer>>, TypedHeaderRejection>,
+    bearer: Result<TypedHeader<Authorization<Bearer>>, TypedHeaderRejection>,
     req: Request<Body>,
     next: Next,
 ) -> Result<Response, Error> {

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -339,14 +339,10 @@ fn process_load_edges<'a, T, I, R>(
     first: Option<usize>,
     last: Option<usize>,
     prefix: Option<&[u8]>,
-) -> (
-    std::vec::Vec<std::result::Result<R, anyhow::Error>>,
-    bool,
-    bool,
-)
+) -> (Vec<anyhow::Result<R>>, bool, bool)
 where
     T: database::Iterable<'a, I>,
-    I: std::iter::Iterator<Item = anyhow::Result<R>>,
+    I: Iterator<Item = anyhow::Result<R>>,
     R: database::UniqueKey,
 {
     let after = after.map(|cursor| cursor.0);
@@ -377,7 +373,7 @@ fn load_edges_interim<'a, T, I, R>(
 ) -> Result<(Vec<R>, bool, bool)>
 where
     T: database::Iterable<'a, I>,
-    I: std::iter::Iterator<Item = anyhow::Result<R>>,
+    I: Iterator<Item = anyhow::Result<R>>,
     R: database::UniqueKey,
 {
     let (nodes, has_previous, has_next) =
@@ -401,7 +397,7 @@ fn load_edges<'a, T, I, R, N, A, NodesField>(
 ) -> Result<Connection<OpaqueCursor<Vec<u8>>, N, A, EmptyFields, NodesField>>
 where
     T: database::Iterable<'a, I>,
-    I: std::iter::Iterator<Item = anyhow::Result<R>>,
+    I: Iterator<Item = anyhow::Result<R>>,
     R: database::UniqueKey,
     N: From<R> + OutputType,
     A: ObjectType,
@@ -436,7 +432,7 @@ fn collect_edges<'a, T, I, R>(
 ) -> (Vec<anyhow::Result<R>>, bool)
 where
     T: database::Iterable<'a, I>,
-    I: std::iter::Iterator<Item = anyhow::Result<R>>,
+    I: Iterator<Item = anyhow::Result<R>>,
     R: database::UniqueKey,
 {
     let edges: Box<dyn Iterator<Item = _>> = if let Some(cursor) = from {


### PR DESCRIPTION
This PR removes unnecessary `std::` prefixes from type names throughout the codebase, improving readability and consistency.

The changes are purely cosmetic and do not affect the functionality of the code.