### PR TITLE
Add `theme` field to `Account` and modify the related APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     Failed to parse "IpAddress": Invalid IP address: abc (occurred while
     parsing "[IpAddress!]")
     ```
+- Added the `theme` field to the `Account` struct to store the user's
+  selected screen color mode. Accordingly, the functions for inserting and
+  updating accounts have been modified, and new APIs have been added to retrieve
+  and update the user's selected screen color mode.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.33.1" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "b2c14a4" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/ip_location.rs
+++ b/src/graphql/ip_location.rs
@@ -26,7 +26,7 @@ impl IpLocationQuery {
             return Err("IP location database unavailable".into());
         };
         let record = {
-            if let Ok(mut locator) = mutex.lock() {
+            if let Ok(locator) = mutex.lock() {
                 locator
                     .ip_lookup(addr)
                     .ok()
@@ -55,7 +55,7 @@ impl IpLocationQuery {
         };
 
         addresses.truncate(MAX_NUM_IP_LOCATION_LIST);
-        let mut locator = mutex
+        let locator = mutex
             .lock()
             .map_err(|_| "Failed to lock IP location database")?;
         let records = addresses


### PR DESCRIPTION
Closes: #370 
Closes: #371 

- Modified related APIs to accommodate the addition of `theme` field in `Account`
- Added new APIs to retrieve and update the user's screen color theme selection