### PR TITLE
Remove unnecessary Mutex for ip2location database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   that previously used source field as a parameter, and GraphQL APIs that return
   event, outlier, or triage related structs.
 - Updated review-database to 0.33.1.
+- The `ip2location::DB` argument for `serve` no longer needs to be wrapped in
+  `Arc` and `Mutex`. This change simplifies the code and improves performance by
+  removing unnecessary locking.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     Failed to parse "IpAddress": Invalid IP address: abc (occurred while
     parsing "[IpAddress!]")
     ```
+- Added the `theme` field to the `Account` struct to store the user's
+  selected screen color mode. Accordingly, the functions for inserting and
+  updating accounts have been modified, and new APIs have been added to retrieve
+  and update the user's selected screen color mode.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.33.1" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "b2c14a4" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ chrono = { version = ">=0.4.35", default-features = false, features = [
 futures = "0.3"
 futures-util = "0.3"
 http = "1"
-ip2location = "0.5"
+ip2location = "0.5.4"
 ipnet = { version = "2", features = ["serde"] }
 jsonwebtoken = "9"
 num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "b2c14a4" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "35b9d80" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -4,7 +4,7 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     process::exit,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 
@@ -313,10 +313,10 @@ async fn run(config: Config) -> Result<Arc<Notify>> {
         config.key.clone(),
     ));
     let ip_locator = if let Some(path) = config.ip2location() {
-        Some(Arc::new(Mutex::new(
+        Some(
             ip2location::DB::from_file(path)
                 .map_err(|e| anyhow!("cannot read IP location database: {:#?}", e))?,
-        )))
+        )
     } else {
         None
     };

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -39,7 +39,7 @@ use std::future::Future;
 use std::net::IpAddr;
 #[cfg(test)]
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_graphql::connection::{
     Connection, ConnectionNameType, CursorType, Edge, EdgeNameType, EmptyFields, OpaqueCursor,
@@ -84,7 +84,7 @@ pub(super) fn schema<B>(
     db: Database,
     store: Arc<RwLock<Store>>,
     agent_manager: B,
-    ip_locator: Option<Arc<Mutex<ip2location::DB>>>,
+    ip_locator: Option<ip2location::DB>,
     cert_manager: Arc<dyn CertManager>,
     cert_reload_handle: Arc<Notify>,
 ) -> Schema

--- a/src/graphql/ip_location.rs
+++ b/src/graphql/ip_location.rs
@@ -26,7 +26,7 @@ impl IpLocationQuery {
             return Err("IP location database unavailable".into());
         };
         let record = {
-            if let Ok(mut locator) = mutex.lock() {
+            if let Ok(locator) = mutex.lock() {
                 locator
                     .ip_lookup(addr)
                     .ok()
@@ -55,7 +55,7 @@ impl IpLocationQuery {
         };
 
         addresses.truncate(MAX_NUM_IP_LOCATION_LIST);
-        let mut locator = mutex
+        let locator = mutex
             .lock()
             .map_err(|_| "Failed to lock IP location database")?;
         let records = addresses

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     io,
     net::SocketAddr,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use async_graphql::{
@@ -60,7 +60,7 @@ pub fn serve<A>(
     config: ServerConfig,
     db: Database,
     store: Arc<RwLock<Store>>,
-    ip_locator: Option<Arc<Mutex<ip2location::DB>>>,
+    ip_locator: Option<ip2location::DB>,
     agent_manager: A,
 ) -> Arc<Notify>
 where


### PR DESCRIPTION
NOTE: This PR builds upon #372. The branch needs to be rebased after #372 has been merged.

The `ip2location::DB` argument for `serve` no longer needs to be wrapped in `Arc` and `Mutex`. This change simplifies the code and improves performance by removing unnecessary locking.