### PR TITLE
Update `insertNode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `WindowsThreat`.
 - The GraphQL API for `WindowsThreat` event structure is changed to return `ID`
   type instead of `usize` type value for the `cluster_id` field.
+- Updated `insertNode` GraphQL API to no longer require `config` for the
+  `agents` parameter.
 
 ### Removed
 

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -311,14 +311,12 @@ mod tests {
                             key: "unsupervised"
                             kind: UNSUPERVISED
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         },
                         {
                             key: "sensor"
                             kind: SENSOR
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         }]
                         giganto: null
@@ -1642,7 +1640,6 @@ mod tests {
                             key: "unsupervised"
                             kind: UNSUPERVISED
                             status: ENABLED
-                            config: null
                             draft: ""
                         }]
                         giganto: null
@@ -1785,14 +1782,12 @@ mod tests {
                             key: "unsupervised"
                             kind: UNSUPERVISED
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         },
                         {
                             key: "sensor"
                             kind: SENSOR
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         }]
                         giganto: null
@@ -1881,14 +1876,12 @@ mod tests {
                             key: "unsupervised"
                             kind: UNSUPERVISED
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         },
                         {
                             key: "sensor"
                             kind: SENSOR
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         }]
                         giganto: null
@@ -1962,14 +1955,12 @@ mod tests {
                             key: "unsupervised"
                             kind: UNSUPERVISED
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         },
                         {
                             key: "sensor"
                             kind: SENSOR
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         }]
                         giganto: null
@@ -2042,14 +2033,12 @@ mod tests {
                             key: "unsupervised"
                             kind: UNSUPERVISED
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         },
                         {
                             key: "sensor"
                             kind: SENSOR
                             status: ENABLED
-                            config: null
                             draft: "test = 'toml'"
                         }]
                         giganto: null

--- a/src/graphql/node/input.rs
+++ b/src/graphql/node/input.rs
@@ -61,9 +61,9 @@ impl From<AgentInput> for review_database::Agent {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, InputObject)]
 pub struct AgentDraftInput {
-    kind: AgentKind,
+    pub(super) kind: AgentKind,
     pub(super) key: String,
-    status: AgentStatus,
+    pub(super) status: AgentStatus,
     pub(super) draft: Option<String>,
 }
 


### PR DESCRIPTION
- `insertNode` GraphQL API no longer requires `config` for the `agents` parameter.

Close: #350 