### PR TITLE
Modify the cluster_id type `usize` to `Option<usize>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - The `ip2location::DB` argument for `serve` no longer needs to be wrapped in
   `Arc` and `Mutex`. This change simplifies the code and improves performance by
   removing unnecessary locking.
+- Modified the type of `cluster_id` field of the detection event structures from
+  `usize` to `Option<usize>`: `HttpThreat`, `ExtraThreat`, `NetworkThreat`,
+  `WindowsThreat`.
+- The GraphQL API for `WindowsThreat` event structure is changed to return `ID`
+  type instead of `usize` type value for the `cluster_id` field.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "35b9d80" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "f59bef0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/event/http.rs
+++ b/src/graphql/event/http.rs
@@ -199,7 +199,10 @@ impl HttpThreat {
     /// The cluster id of the event in string wthin the range representable
     /// by a `usize`.
     async fn cluster_id(&self) -> ID {
-        ID(self.inner.cluster_id.to_string())
+        ID(self
+            .inner
+            .cluster_id
+            .map_or(String::new(), |id| id.to_string()))
     }
 
     async fn attack_kind(&self) -> &str {

--- a/src/graphql/event/log.rs
+++ b/src/graphql/event/log.rs
@@ -45,7 +45,10 @@ impl ExtraThreat {
     /// The cluster id of the event in string wthin the range representable
     /// by a `usize`.
     async fn cluster_id(&self) -> ID {
-        ID(self.inner.cluster_id.to_string())
+        ID(self
+            .inner
+            .cluster_id
+            .map_or(String::new(), |id| id.to_string()))
     }
 
     async fn attack_kind(&self) -> &str {

--- a/src/graphql/event/network.rs
+++ b/src/graphql/event/network.rs
@@ -109,7 +109,10 @@ impl NetworkThreat {
     /// The cluster ID of the event in string within the representable
     /// range of `usize`.
     async fn cluster_id(&self) -> ID {
-        ID(self.inner.cluster_id.to_string())
+        ID(self
+            .inner
+            .cluster_id
+            .map_or(String::new(), |id| id.to_string()))
     }
 
     async fn attack_kind(&self) -> &str {

--- a/src/graphql/event/sysmon.rs
+++ b/src/graphql/event/sysmon.rs
@@ -1,4 +1,4 @@
-use async_graphql::Object;
+use async_graphql::{Object, ID};
 use chrono::{DateTime, Utc};
 use review_database as database;
 
@@ -64,8 +64,11 @@ impl WindowsThreat {
         &self.inner.matched_to
     }
 
-    async fn cluster_id(&self) -> usize {
-        self.inner.cluster_id
+    async fn cluster_id(&self) -> ID {
+        ID(self
+            .inner
+            .cluster_id
+            .map_or(String::new(), |id| id.to_string()))
     }
 
     async fn attack_kind(&self) -> &str {

--- a/src/graphql/model.rs
+++ b/src/graphql/model.rs
@@ -448,7 +448,7 @@ struct ElementCount<'a> {
 }
 
 #[Object]
-impl<'a> ElementCount<'a> {
+impl ElementCount<'_> {
     async fn value(&self) -> &str {
         &self.inner.value
     }


### PR DESCRIPTION
Close #384 

Modify the type of `cluster_id` field of the detection event structures from `usize` to `Option<usize>`:
- `HttpThreat`, `ExtraThreat`, `NetworkThreat`, `WindowsThreat`