### PR TITLE
Remove obsolete reset_admin_password function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `Arc` and `Mutex`. This change simplifies the code and improves performance by
   removing unnecessary locking.
 
+### Removed
+
+- Removed `graphql::account::reset_admin_password` function as it was obsoleted
+  by the GraphQL API `resetAdminPassword`.
+
 ### Fixed
 
 - Resolved an issue in the `applyNode` GraphQL API, where configuration values

--- a/src/graphql/account.rs
+++ b/src/graphql/account.rs
@@ -803,17 +803,6 @@ pub fn set_initial_admin_password(store: &Store) -> anyhow::Result<()> {
     map.insert(&account)
 }
 
-/// Resets the administrator password to the initial value.
-///
-/// # Errors
-///
-/// This function returns an error if it fails to generate random bytes for password.
-pub fn reset_admin_password(store: &Store) -> anyhow::Result<()> {
-    let map = store.account_map();
-    let account = initial_credential()?;
-    map.put(&account)
-}
-
 /// Returns the initial administrator username and salted password.
 ///
 /// # Errors


### PR DESCRIPTION
This PR removes the `reset_admin_password` function from the `graphql::account` module, as it has been obsoleted by the `resetAdminPassword` GraphQL API mutation.

The `reset_admin_password` function was previously used by the QUIC API, but since the QUIC API has been replaced with the GraphQL API mutation instead, this function is no longer needed.

**Note:** CI is currently failing due to a Clippy warning, but this will be resolved once #385 is merged.