### PR TITLE
Simplify trusted user agent list broadcasting API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - The `insertAccount` and `updateAccount` GraphQL APIs remain unchanged in
     their interfaces but now only accept parameters related to max parallel
     sessions within the range of `u8`.
+- Changed `AgentManager::broadcast_trusted_user_agent_list` method signature
+  from `&[u8]` to `&[String]`. Implementors of `AgentManager` will need to
+  update their implementations. This change simplifies the API by removing
+  serialization concerns from callers.
 
 ### Removed
 

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -70,7 +70,10 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
-    async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
+    async fn broadcast_trusted_user_agent_list(
+        &self,
+        _list: &[String],
+    ) -> Result<(), anyhow::Error> {
         bail!("Not supported")
     }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -29,7 +29,10 @@ pub trait AgentManager: Send + Sync {
         networks: &HostNetworkGroup,
     ) -> Result<Vec<String>, anyhow::Error>;
 
-    async fn broadcast_trusted_user_agent_list(&self, _list: &[u8]) -> Result<(), anyhow::Error> {
+    async fn broadcast_trusted_user_agent_list(
+        &self,
+        _list: &[String],
+    ) -> Result<(), anyhow::Error> {
         Err(anyhow!("Not supported"))
     }
 

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -2102,7 +2102,7 @@ mod tests {
         }
         async fn broadcast_trusted_user_agent_list(
             &self,
-            _list: &[u8],
+            _list: &[String],
         ) -> Result<(), anyhow::Error> {
             anyhow::bail!("not expected to be called")
         }
@@ -2202,7 +2202,7 @@ mod tests {
         }
         async fn broadcast_trusted_user_agent_list(
             &self,
-            _list: &[u8],
+            _list: &[String],
         ) -> Result<(), anyhow::Error> {
             anyhow::bail!("not expected to be called")
         }

--- a/src/graphql/trusted_user_agent.rs
+++ b/src/graphql/trusted_user_agent.rs
@@ -3,7 +3,6 @@ use async_graphql::{
     connection::{Connection, EmptyFields},
     Context, Object, Result, SimpleObject,
 };
-use bincode::Options;
 use chrono::{DateTime, Utc};
 use database::{Direction, Iterable};
 use review_database::{self as database, Store};
@@ -114,10 +113,9 @@ impl UserAgentMutation {
     async fn apply_trusted_user_agent(&self, ctx: &Context<'_>) -> Result<bool> {
         let store = crate::graphql::get_store(ctx).await?;
         let list = get_trusted_user_agent_list(&store)?;
-        let serialized_user_agent = bincode::DefaultOptions::new().serialize(&list)?;
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager
-            .broadcast_trusted_user_agent_list(&serialized_user_agent)
+            .broadcast_trusted_user_agent_list(&list)
             .await?;
         Ok(true)
     }


### PR DESCRIPTION
This PR changes the `AgentManager::broadcast_trusted_user_agent_list` method signature to accept a slice of strings instead of raw bytes. This makes the API more intuitive and moves serialization concerns into the implementations where they belong.