### PR TITLE
Modify to broadcast the correct internal networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,20 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   from `&[u8]` to `&[String]`. Implementors of `AgentManager` will need to
   update their implementations. This change simplifies the API by removing
   serialization concerns from callers.
+- Modified to broadcast the correct internal network list for each
+  Semi-supervised Engine. The changes are as follows.
+  - Renamed the `broadcast_internal_networks` method of to `AgentManager` trait
+    to `send_agent_specific_internal_networks` as the functionality of
+    `broadcast_internal_networks` changes from broadcast to fine-targeting nodes
+    and agents using agent keys and hostnames to send.
+  - Changed the argument type of the `send_agent_specific_internal_networks`
+    method from `HostNetworkGroup` to `NetworksTargetAgentKeysPair` array. This
+    change will allow the Central Management Server that implements
+    `send_agent_specific_internal_networks` to provide the internal networks
+    corresponding to the agent information of the Semi-supervised Engine.
+  - Renamed `get_customer_id_of_node` to `agent_keys_by_customer_id` as the
+    functionality of `get_customer_id_of_node` has changed. The function returns
+    agent info list by all customer id.
 
 ### Removed
 

--- a/examples/minireview.rs
+++ b/examples/minireview.rs
@@ -20,7 +20,10 @@ use review_database::{migrate_data_dir, Database, HostNetworkGroup, Store};
 use review_web::{
     self as web,
     backend::{AgentManager, CertManager},
-    graphql::{account::set_initial_admin_password, Process, ResourceUsage, SamplingPolicy},
+    graphql::{
+        account::set_initial_admin_password, customer::NetworksTargetAgentKeysPair, Process,
+        ResourceUsage, SamplingPolicy,
+    },
 };
 use serde::Deserialize;
 use tokio::{
@@ -77,9 +80,9 @@ impl AgentManager for Manager {
         bail!("Not supported")
     }
 
-    async fn broadcast_internal_networks(
+    async fn send_agent_specific_internal_networks(
         &self,
-        _networks: &HostNetworkGroup,
+        _networks: &[NetworksTargetAgentKeysPair],
     ) -> Result<Vec<String>, Error> {
         bail!("Not supported")
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -6,6 +6,7 @@ use ipnet::IpNet;
 use review_database::HostNetworkGroup;
 pub use roxy::{Process, ResourceUsage};
 
+use crate::graphql::customer::NetworksTargetAgentKeysPair;
 pub use crate::graphql::{ParsedCertificate, SamplingPolicy};
 
 #[async_trait]
@@ -14,9 +15,9 @@ pub trait AgentManager: Send + Sync {
         Err(anyhow!("Not supported"))
     }
 
-    async fn broadcast_internal_networks(
+    async fn send_agent_specific_internal_networks(
         &self,
-        networks: &HostNetworkGroup,
+        networks: &[NetworksTargetAgentKeysPair],
     ) -> Result<Vec<String>, anyhow::Error>;
 
     async fn broadcast_allow_networks(

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -9,7 +9,7 @@ mod block_network;
 mod category;
 mod cert;
 mod cluster;
-pub(crate) mod customer;
+pub mod customer;
 mod data_source;
 mod db_management;
 mod event;
@@ -62,7 +62,7 @@ pub use self::allow_network::get_allow_networks;
 pub use self::block_network::get_block_networks;
 pub use self::cert::ParsedCertificate;
 pub use self::customer::get_customer_networks;
-pub use self::node::get_customer_id_of_node;
+pub use self::node::agent_keys_by_customer_id;
 pub use self::sampling::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod,
     Policy as SamplingPolicy,
@@ -594,9 +594,9 @@ impl AgentManager for MockAgentManager {
         Ok(())
     }
 
-    async fn broadcast_internal_networks(
+    async fn send_agent_specific_internal_networks(
         &self,
-        _networks: &HostNetworkGroup,
+        _networks: &[customer::NetworksTargetAgentKeysPair],
     ) -> Result<Vec<String>, anyhow::Error> {
         Ok(vec!["semi-supervised@hostA".to_string()])
     }

--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -12,12 +12,16 @@ use async_graphql::{
 use bincode::Options;
 use chrono::{DateTime, TimeZone, Utc};
 #[allow(clippy::module_name_repetitions)]
-pub use crud::get_customer_id_of_node;
+pub use crud::agent_keys_by_customer_id;
 use database::Indexable;
 use input::NodeInput;
 use review_database as database;
 use roxy::Process as RoxyProcess;
 use serde::{Deserialize, Serialize};
+
+const SENSOR_AGENT: &str = "piglet";
+const UNSUPERVISED_AGENT: &str = "reconverge";
+pub(super) const SEMI_SUPERVISED_AGENT: &str = "hog";
 
 #[derive(Default)]
 pub(super) struct NodeQuery;
@@ -364,4 +368,13 @@ pub fn matches_manager_hostname(hostname: &str) -> bool {
     // the Manager server.
     let manager_hostname = roxy::hostname();
     !manager_hostname.is_empty() && manager_hostname == hostname
+}
+
+fn gen_agent_key(kind: AgentKind, host_name: &str) -> Result<String> {
+    match kind {
+        AgentKind::Unsupervised => Ok(format!("{UNSUPERVISED_AGENT}@{host_name}")),
+        AgentKind::Sensor => Ok(format!("{SENSOR_AGENT}@{host_name}")),
+        AgentKind::SemiSupervised => Ok(format!("{SEMI_SUPERVISED_AGENT}@{host_name}")),
+        AgentKind::TimeSeriesGenerator => Err(anyhow::anyhow!("invalid node's agent type").into()),
+    }
 }

--- a/src/graphql/node/input.rs
+++ b/src/graphql/node/input.rs
@@ -38,7 +38,7 @@ impl fmt::Display for NodeProfileInput {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, InputObject)]
 pub struct AgentInput {
-    kind: AgentKind,
+    pub(super) kind: AgentKind,
     pub(super) key: String,
     status: AgentStatus,
     pub(super) config: Option<String>,

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -111,7 +111,10 @@ mod tests {
     use roxy::ResourceUsage;
     use serde_json::json;
 
-    use crate::graphql::{AgentManager, BoxedAgentManager, SamplingPolicy, TestSchema};
+    use crate::graphql::{
+        customer::NetworksTargetAgentKeysPair, AgentManager, BoxedAgentManager, SamplingPolicy,
+        TestSchema,
+    };
 
     struct MockAgentManager {
         pub online_apps_by_host_id: HashMap<String, Vec<(String, String)>>,
@@ -119,9 +122,9 @@ mod tests {
 
     #[async_trait]
     impl AgentManager for MockAgentManager {
-        async fn broadcast_internal_networks(
+        async fn send_agent_specific_internal_networks(
             &self,
-            _networks: &HostNetworkGroup,
+            _networks: &[NetworksTargetAgentKeysPair],
         ) -> Result<Vec<String>, anyhow::Error> {
             anyhow::bail!("not expected to be called")
         }


### PR DESCRIPTION
- Add `NetworksAgentKeysPair` structure that stores the internal
  networks and a list of agent information that use that networks.
- Rename the `broadcast_internal_networks` method of to `AgentManager`
   trait to `send_agent_specific_internal_networks`.
- Change the argument type of `send_agent_specific_internal_networks`
  method from `HostNetworkGroup` to `NetworksTargetAgentKeysPair` array.
- Remove the part that broadcasts when registering a Central Management
  Server node from the `insertNode` GraphQL API.
- Modify the `removeCustomers`, `updateCustomer` GraphQL API to
  generate information about internal networks as
  `Vec<NetworksAgentKeysPair>` instead of `HostNetworkGroup`.
- Rename `get_customer_id_of_node` to `agent_keys_by_customer_id` as
  the functionality of `get_customer_id_of_node` has changed.

Close: #389 