### PR TITLE
Fix improper access control in GraphQL APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a security issue where the `language`, `updateLanguage`, `theme`, and
+  `updateTheme` APIs allowed changing another user's settings by providing a
+  different `username` parameter.
+  - The `username` parameter has been removed, and the APIs now extract the
+    username from the JWT for authorization.
+
 ## [0.25.0] - 2025-01-27
 
 ### Added
@@ -811,6 +821,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - An initial version.
 
+[Unreleased]: https://github.com/aicers/review-web/compare/0.25.0...main
 [0.25.0]: https://github.com/aicers/review-web/compare/0.24.0...0.25.0
 [0.24.0]: https://github.com/aicers/review-web/compare/0.23.0...0.24.0
 [0.23.0]: https://github.com/aicers/review-web/compare/0.22.0...0.23.0

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -669,10 +669,14 @@ struct TestSchema {
 impl TestSchema {
     async fn new() -> Self {
         let agent_manager: BoxedAgentManager = Box::new(MockAgentManager {});
-        Self::new_with(agent_manager, None).await
+        Self::new_with_params(agent_manager, None, "testuser").await
     }
 
-    async fn new_with(agent_manager: BoxedAgentManager, test_addr: Option<SocketAddr>) -> Self {
+    async fn new_with_params(
+        agent_manager: BoxedAgentManager,
+        test_addr: Option<SocketAddr>,
+        username: &str,
+    ) -> Self {
         use self::account::set_initial_admin_password;
 
         let db_dir = tempfile::tempdir().unwrap();
@@ -680,6 +684,7 @@ impl TestSchema {
         let store = Store::new(db_dir.path(), backup_dir.path()).unwrap();
         let _ = set_initial_admin_password(&store);
         let store = Arc::new(RwLock::new(store));
+
         let schema = Schema::build(
             Query::default(),
             Mutation::default(),
@@ -687,8 +692,9 @@ impl TestSchema {
         )
         .data(agent_manager)
         .data(store.clone())
-        .data("testuser".to_string())
+        .data(username.to_string())
         .finish();
+
         Self {
             _dir: db_dir,
             store,

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -308,7 +308,7 @@ mod tests {
             available_agents: vec!["unsupervised@all-in-one", "sensor@all-in-one"],
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // check empty
         let res = schema.execute(r"{nodeList{totalCount}}").await;
@@ -1641,7 +1641,7 @@ mod tests {
             online_apps_by_host_id: HashMap::new(),
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // insert node
         let res = schema
@@ -1783,7 +1783,7 @@ mod tests {
             available_agents: vec!["unsupervised@all-in-one", "sensor@all-in-one"],
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // insert node
         let res = schema
@@ -1877,7 +1877,7 @@ mod tests {
             available_agents: vec!["unsupervised@all-in-one", "sensor@all-in-one"],
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // insert node
         let res = schema
@@ -1956,7 +1956,7 @@ mod tests {
             available_agents: vec!["unsupervised@all-in-one", "sensor@all-in-one"],
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // insert node
         let res = schema
@@ -2034,7 +2034,7 @@ mod tests {
             online_apps_by_host_id: HashMap::new(),
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // insert node
         let res = schema
@@ -2309,7 +2309,7 @@ mod tests {
             available_agents: vec!["semi-supervised@analysis"],
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // node_shutdown
         let res = schema

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -222,7 +222,7 @@ mod tests {
             online_apps_by_host_id,
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // check empty
         let res = schema.execute(r"{nodeList{totalCount}}").await;
@@ -479,7 +479,7 @@ mod tests {
             online_apps_by_host_id,
         });
 
-        let schema = TestSchema::new_with(agent_manager, None).await;
+        let schema = TestSchema::new_with_params(agent_manager, None, "testuser").await;
 
         // Insert 5 nodes
         let res = schema

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -203,7 +203,7 @@ mod tests {
     async fn update_trusted_domain() {
         let agent_manager: BoxedAgentManager = Box::new(MockAgentManager {});
         let test_addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-        let schema = TestSchema::new_with(agent_manager, Some(test_addr)).await;
+        let schema = TestSchema::new_with_params(agent_manager, Some(test_addr), "testuser").await;
         let insert_query = r#"
               mutation {
                 insertTrustedDomain(


### PR DESCRIPTION
- Removed the `username` parameter from the language and theme APIs to prevent unauthorized modifications and enforce JWT-based authentication.

Close: #378 