### PR TITLE
Fix missing config error in `updateNodeDraft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   different `username` parameter.
   - The `username` parameter has been removed, and the APIs now extract the
     username from the JWT for authorization.
+- Fixed an issue where `updateNodeDraft` could sometimes result in a
+  "Missing configuration for agent" error when modifying agent settings.
 
 ## [0.25.0] - 2025-01-27
 

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -699,4 +699,180 @@ mod tests {
             })
         );
     }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn update_node_agents() {
+        let schema = TestSchema::new().await;
+
+        // Check initial node list (should be empty)
+        let res = schema.execute(r"{nodeList{totalCount}}").await;
+        assert_eq!(res.data.to_string(), r"{nodeList: {totalCount: 0}}");
+
+        // Insert node with unsupervised and semi-supervised agents
+        let res = schema
+            .execute(
+                r#"mutation {
+                    insertNode(
+                        name: "admin node",
+                        customerId: 0,
+                        description: "This is the admin node running review.",
+                        hostname: "admin.aice-security.com",
+                        agents: [{
+                            key: "unsupervised",
+                            kind: UNSUPERVISED
+                            status: ENABLED
+                        },
+                        {
+                            key: "semi-supervised",
+                            kind: SEMI_SUPERVISED
+                            status: ENABLED
+                        }]
+                        giganto: null
+                    )
+                }"#,
+            )
+            .await;
+        assert_eq!(res.data.to_string(), r#"{insertNode: "0"}"#);
+
+        // Check node count after insert
+        let res = schema.execute(r"{nodeList{totalCount}}").await;
+        assert_eq!(res.data.to_string(), r"{nodeList: {totalCount: 1}}");
+
+        // Remove the unsupervised agent
+        let res = schema
+            .execute(
+                r#"mutation {
+                updateNodeDraft(
+                    id: "0",
+                    old: {
+                        name: "admin node",
+                        nameDraft: "admin node",
+                        profile: null,
+                        profileDraft: {
+                            customerId: 0,
+                            description: "This is the admin node running review.",
+                            hostname: "admin.aice-security.com",
+                        },
+                        agents: [
+                            {
+                                key: "unsupervised",
+                                kind: UNSUPERVISED,
+                                status: ENABLED,
+                                config: null,
+                                draft: null
+                            },
+                            {
+                                key: "semi-supervised",
+                                kind: SEMI_SUPERVISED,
+                                status: ENABLED,
+                                config: null,
+                                draft: null
+                            }
+                        ],
+                        giganto: null
+                    },
+                    new: {
+                        nameDraft: "admin node",
+                        agents: [
+                            {
+                                key: "semi-supervised",
+                                kind: SEMI_SUPERVISED,
+                                status: ENABLED,
+                                draft: null
+                            }
+                        ],
+                        giganto: null
+                    }
+                )
+            }"#,
+            )
+            .await;
+        assert_eq!(res.data.to_string(), r#"{updateNodeDraft: "0"}"#);
+
+        // Add a sensor agent
+        let res = schema
+            .execute(
+                r#"mutation {
+                updateNodeDraft(
+                    id: "0",
+                    old: {
+                        name: "admin node",
+                        nameDraft: "admin node",
+                        profile: null,
+                        profileDraft: null,
+                        agents: [
+                            {
+                                key: "semi-supervised",
+                                kind: SEMI_SUPERVISED,
+                                status: ENABLED,
+                                config: null,
+                                draft: null
+                            }
+                        ],
+                        giganto: null
+                    },
+                    new: {
+                        nameDraft: "admin node",
+                        agents: [
+                            {
+                                key: "semi-supervised",
+                                kind: SEMI_SUPERVISED,
+                                status: ENABLED,
+                                draft: null
+                            },
+                            {
+                                key: "sensor",
+                                kind: SENSOR,
+                                status: ENABLED,
+                                draft: null
+                            }
+                        ],
+                        giganto: null
+                    }
+                )
+            }"#,
+            )
+            .await;
+        assert_eq!(res.data.to_string(), r#"{updateNodeDraft: "0"}"#);
+
+        // Check final node state
+        let res = schema
+            .execute(
+                r#"{node(id: "0") {
+                id
+                name
+                nameDraft
+                agents {
+                    key
+                    kind
+                    status
+                }
+            }}"#,
+            )
+            .await;
+
+        assert_json_eq!(
+            res.data.into_json().unwrap(),
+            json!({
+                "node": {
+                    "id": "0",
+                    "name": "admin node",
+                    "nameDraft": "admin node",
+                    "agents": [
+                        {
+                            "key": "semi-supervised",
+                            "kind": "SEMI_SUPERVISED",
+                            "status": "ENABLED"
+                        },
+                        {
+                            "key": "sensor",
+                            "kind": "SENSOR",
+                            "status": "ENABLED"
+                        }
+                    ]
+                }
+            })
+        );
+    }
 }

--- a/src/graphql/node/input.rs
+++ b/src/graphql/node/input.rs
@@ -154,12 +154,7 @@ pub(super) fn create_draft_update(
                             })?),
                             None => None,
                         },
-                        None => {
-                            return Err(Error::new(format!(
-                                "Missing configuration for the agent: {}",
-                                new_agent.key
-                            )));
-                        }
+                        None => None,
                     };
 
                     let draft = match new_agent.draft {
@@ -181,7 +176,7 @@ pub(super) fn create_draft_update(
                         draft,
                     })
                 })
-                .collect::<Result<Vec<_>, _>>()
+                .collect::<Result<Vec<_>, Error>>()
         })
         .transpose()?
         .unwrap_or_default();


### PR DESCRIPTION
Previously, when an agent was newly added in `updateNodeDraft`, its configuration was expected to be present in `old_config_map`. To maintain consistency with `insertNode`, the logic was updated to return `None` instead of an error when a newly added agent does not exist in `old_config_map`.

Close: #410 