### PR TITLE
Fix 'EventListFilterInput::kinds' filtering issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     username from the JWT for authorization.
 - Fixed a bug in the `updateNodeDraft` GraphQL API where adding a new agent to
   an already configured node could fail.
+- Fixed an issue where GraphQL APIs using `EventListFilterInput` failed to
+  filter events by `kinds`.
 
 ### Removed
 

--- a/src/graphql/event/group.rs
+++ b/src/graphql/event/group.rs
@@ -234,7 +234,8 @@ impl EventGroupQuery {
                 .map_or(i128::MAX, |t| i128::from(t) << 64);
             if end > 0 { end - 1 } else { 0 }
         });
-        let filter = from_filter_input(ctx, &store, &filter)?;
+        let mut filter = from_filter_input(ctx, &store, &filter)?;
+        filter.moderate_kinds();
         let db = store.events();
         let locator = if filter.has_country() {
             Some(
@@ -311,7 +312,8 @@ async fn count_events<T>(
             .map_or(i128::MAX, |t| i128::from(t) << 64);
         if end > 0 { end - 1 } else { 0 }
     });
-    let filter = from_filter_input(ctx, &store, filter)?;
+    let mut filter = from_filter_input(ctx, &store, filter)?;
+    filter.moderate_kinds();
     let db = store.events();
     let locator = ctx.data::<ip2location::DB>().ok();
 
@@ -363,7 +365,8 @@ async fn count_events_by_network(
             .map_or(i128::MAX, |t| i128::from(t) << 64);
         if end > 0 { end - 1 } else { 0 }
     });
-    let filter = from_filter_input(ctx, &store, filter)?;
+    let mut filter = from_filter_input(ctx, &store, filter)?;
+    filter.moderate_kinds();
     let db = store.events();
     let locator = ctx.data::<ip2location::DB>().ok();
 


### PR DESCRIPTION
- Fix an issue where GraphQL APIs using `EventListFilterInput` failed to filter events by `kinds`.

Close: #429