### PR TITLE
Update review-database to 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ this project adheres to
     `triageResponseList`.
 - Updated `removeTrustedDomain` GraphQL API to `removeTrustedDomains` to support
   multiple removals.
+- Updated review-database to 0.37.0, which fixes event filtering by multiple IP
+  addresses for `ExternalDdos`, `MultiHostPortScan`, and `RdpBruteForce`.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "3db5205" }
+review-database = { git = "https://github.com/petabi/review-database.git", tag = "0.37.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",


### PR DESCRIPTION
This fixes event filtering by multiple IP addresses for `ExternalDdos`, `MultiHostPortScan`, and `RdpBruteForce`.

This would allow applications depending on review-web to use up-to-date review-database, benefiting from its bug fixes and improvements.