### PR TITLE
Change host_name to hostname in `gen_agent_key()`

### DIFF
--- a/src/graphql/node.rs
+++ b/src/graphql/node.rs
@@ -370,11 +370,11 @@ pub fn matches_manager_hostname(hostname: &str) -> bool {
     !manager_hostname.is_empty() && manager_hostname == hostname
 }
 
-fn gen_agent_key(kind: AgentKind, host_name: &str) -> Result<String> {
+fn gen_agent_key(kind: AgentKind, hostname: &str) -> Result<String> {
     match kind {
-        AgentKind::Unsupervised => Ok(format!("{UNSUPERVISED_AGENT}@{host_name}")),
-        AgentKind::Sensor => Ok(format!("{SENSOR_AGENT}@{host_name}")),
-        AgentKind::SemiSupervised => Ok(format!("{SEMI_SUPERVISED_AGENT}@{host_name}")),
+        AgentKind::Unsupervised => Ok(format!("{UNSUPERVISED_AGENT}@{hostname}")),
+        AgentKind::Sensor => Ok(format!("{SENSOR_AGENT}@{hostname}")),
+        AgentKind::SemiSupervised => Ok(format!("{SEMI_SUPERVISED_AGENT}@{hostname}")),
         AgentKind::TimeSeriesGenerator => Err(anyhow::anyhow!("invalid node's agent type").into()),
     }
 }


### PR DESCRIPTION
## Related Issues 
closes #446

## PR Description
- Change host_name parameter to hostname in gen_agent_key function
- Maintain consistency with other parts of the codebase that already use hostname