### PR TITLE
Remove explicit scopes due to RocksDB 0.23.0

### DIFF
--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -92,14 +92,12 @@ impl NodeControlMutation {
         }
 
         if let Some(ref target_agents) = apply_scope.agents {
-            let hostname = {
-                let store = crate::graphql::get_store(ctx).await?;
-                let node_map = store.node_map();
-                let (node, _) = node_map.get_by_id(i)?.ok_or_else(|| {
-                    async_graphql::Error::new(format!("Node with ID {i} not found"))
-                })?;
-                node.profile.map(|p| p.hostname).unwrap_or_default()
-            };
+            let store = crate::graphql::get_store(ctx).await?;
+            let node_map = store.node_map();
+            let (node, _) = node_map
+                .get_by_id(i)?
+                .ok_or_else(|| async_graphql::Error::new(format!("Node with ID {i} not found")))?;
+            let hostname = node.profile.map(|p| p.hostname).unwrap_or_default();
 
             if hostname.is_empty() {
                 info!(

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -46,11 +46,10 @@ async fn load(
     first: Option<usize>,
     last: Option<usize>,
 ) -> Result<Connection<OpaqueCursor<Vec<u8>>, NodeStatus, NodeStatusTotalCount, EmptyFields>> {
-    let (node_list, has_previous, has_next) = {
-        let store = crate::graphql::get_store(ctx).await?;
-        let map = store.node_map();
-        super::super::load_edges_interim(&map, after, before, first, last, None)?
-    };
+    let store = crate::graphql::get_store(ctx).await?;
+    let map = store.node_map();
+    let (node_list, has_previous, has_next) =
+        super::super::load_edges_interim(&map, after, before, first, last, None)?;
 
     let agent_manager = ctx.data::<BoxedAgentManager>()?;
 

--- a/src/graphql/sampling.rs
+++ b/src/graphql/sampling.rs
@@ -365,11 +365,9 @@ impl SamplingPolicyMutation {
             creation_time: chrono::Utc::now(),
         };
 
-        let id = {
-            let store = crate::graphql::get_store(ctx).await?;
-            let map = store.sampling_policy_map();
-            map.put(pol.clone())?
-        };
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.sampling_policy_map();
+        let id = map.put(pol.clone())?;
 
         if immutable {
             let agents = ctx.data::<BoxedAgentManager>()?;

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -50,17 +50,14 @@ impl TrustedDomainMutation {
         name: String,
         remarks: String,
     ) -> Result<String> {
-        let name = {
-            let store = crate::graphql::get_store(ctx).await?;
-            let map = store.trusted_domain_map();
-            let entry = review_database::TrustedDomain { name, remarks };
-            map.put(&entry)?;
-            entry.name
-        };
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.trusted_domain_map();
+        let entry = review_database::TrustedDomain { name, remarks };
+        map.put(&entry)?;
 
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager.broadcast_trusted_domains().await?;
-        Ok(name)
+        Ok(entry.name)
     }
 
     /// Updates a trusted domain, returning the new value.
@@ -72,18 +69,15 @@ impl TrustedDomainMutation {
         old: TrustedDomainInput,
         new: TrustedDomainInput,
     ) -> Result<String> {
-        let name = {
-            let store = crate::graphql::get_store(ctx).await?;
-            let map = store.trusted_domain_map();
-            let old = review_database::TrustedDomain::from(old);
-            let new = review_database::TrustedDomain::from(new);
-            map.update(&old, &new)?;
-            new.name
-        };
+        let store = crate::graphql::get_store(ctx).await?;
+        let map = store.trusted_domain_map();
+        let old = review_database::TrustedDomain::from(old);
+        let new = review_database::TrustedDomain::from(new);
+        map.update(&old, &new)?;
 
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager.broadcast_trusted_domains().await?;
-        Ok(name)
+        Ok(new.name)
     }
 
     /// Removes multiple trusted domains, returning the removed values.


### PR DESCRIPTION
## Related Issues
Closes #413

## PR Description
Removes unnecessary explicit scope blocks in RocksDB operations following the
Send/Sync trait improvements in RocksDB 0.23.0.

Before:
```rust
let id = {
    let store = crate::graphql::get_store(ctx).await?;
    let map = store.sampling_policy_map();
    map.put(pol.clone())?
};
```

After:
```rust
let store = crate::graphql::get_store(ctx).await?;
let map = store.sampling_policy_map();
let id = map.put(pol.clone())?;
```
