### PR TITLE
Modify code related to the packet attribute triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ this project adheres to
     instead of just the new password.
   - Both APIs now validate that the new password is different from the current
     password and reject changes that attempt to reuse the current password.
+- Modified code related to the packet attribute triage. The scoring
+  functionality for packet attribute triage was previously not implemented, but
+  is now correctly supported on the review-database side. To reflect this,
+  the related code has been updated accordingly.
+  - A new field `raw_event_kind` of type `RawEventKind` has been added to `PacketAttrInput`.
+  - The same field has also been added as a return field to `PacketAttr`, which
+    is one of the types used in triage-related GraphQL API queries.
+  - Introduced new enum variants (`UInteger`, `Vector`, `IpAddr`, `Bool`) to the
+    `ValueKind` enum for strict type matching of packet attributes.
+  - This changes affects GraphQL APIs such as `insertTriagePolicy`,
+    `updateTriagePolicy` , `triagePolicyList`, and `triagePolicy`. They may
+    introduce breaking changes for clients relying on the previous GraphQL schema.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 async-graphql = { version = "7", features = ["chrono", "string_number"] }
 async-graphql-axum = "7"
 async-trait = "0.1"
+attrievent = { git = "https://github.com/aicers/attrievent.git", tag = "0.2.1" }
 axum = { version = "0.8", features = ["macros", "tokio", "ws"] }
 axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
@@ -25,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "9805029" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "32c0d76" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/triage.rs
+++ b/src/graphql/triage.rs
@@ -4,6 +4,7 @@ mod policy;
 pub(super) mod response;
 
 use async_graphql::{Enum, ID, InputObject, Object};
+use attrievent::attribute as attr;
 use chrono::{DateTime, Utc};
 use review_database as database;
 use serde::Deserialize;
@@ -73,11 +74,39 @@ enum TiCmpKind {
 }
 
 #[derive(Clone, Copy, Enum, Eq, PartialEq, Deserialize)]
+#[graphql(remote = "attr::RawEventKind")]
+pub enum RawEventKind {
+    Bootp,
+    Conn,
+    Dhcp,
+    Dns,
+    Ftp,
+    Http,
+    Kerberos,
+    Ldap,
+    Log,
+    Mqtt,
+    Network,
+    Nfs,
+    Ntlm,
+    Rdp,
+    Smb,
+    Smtp,
+    Ssh,
+    Tls,
+    Window,
+}
+
+#[derive(Clone, Copy, Enum, Eq, PartialEq, Deserialize)]
 #[graphql(remote = "database::ValueKind")]
 pub enum ValueKind {
     String,
     Integer,
+    UInteger,
+    Vector,
     Float,
+    IpAddr,
+    Bool,
 }
 
 #[derive(Clone, Copy, Enum, Eq, PartialEq, Deserialize)]
@@ -158,6 +187,10 @@ struct PacketAttr<'a> {
 
 #[Object]
 impl PacketAttr<'_> {
+    async fn raw_event_kind(&self) -> RawEventKind {
+        self.inner.raw_event_kind.into()
+    }
+
     async fn attr_name(&self) -> &str {
         &self.inner.attr_name
     }
@@ -258,6 +291,7 @@ impl From<&TiInput> for database::Ti {
 
 #[derive(Clone, InputObject)]
 pub(super) struct PacketAttrInput {
+    raw_event_kind: RawEventKind,
     attr_name: String,
     value_kind: ValueKind,
     cmp_kind: AttrCmpKind,
@@ -324,6 +358,7 @@ impl From<TriagePolicyInput> for database::TriagePolicyUpdate {
 impl From<&PacketAttrInput> for database::PacketAttr {
     fn from(p: &PacketAttrInput) -> Self {
         Self {
+            raw_event_kind: p.raw_event_kind.into(),
             attr_name: p.attr_name.clone(),
             value_kind: p.value_kind.into(),
             cmp_kind: p.cmp_kind.into(),
@@ -362,13 +397,15 @@ mod tests {
                             weight: 0.5
                         }]
                         packetAttr: [{
-                            attrName: "conn-resp_pkts"
+                            rawEventKind: CONN
+                            attrName: "Packets Received"
                             valueKind: STRING
                             cmpKind: CONTAIN
                             firstValue: [4, 80, 79, 83, 84]
                             weight: 0.5
                         }, {
-                            attrName: "conn-resp_pkts"
+                            rawEventKind: CONN
+                            attrName: "Packets Received"
                             valueKind: INTEGER
                             cmpKind: GREATER_OR_EQUAL
                             firstValue: [251, 88, 2]
@@ -414,13 +451,15 @@ mod tests {
                                 weight: 0.5
                             }]
                             packetAttr: [{
-                                attrName: "conn-resp_pkts"
+                                rawEventKind: CONN
+                                attrName: "Packets Received"
                                 valueKind: STRING
                                 cmpKind: CONTAIN
                                 firstValue: [4, 80, 79, 83, 84]
                                 weight: 0.5
                             }, {
-                                attrName: "conn-resp_pkts"
+                                rawEventKind: CONN
+                                attrName: "Packets Received"
                                 valueKind: INTEGER
                                 cmpKind: GREATER_OR_EQUAL
                                 firstValue: [251, 88, 2]
@@ -455,13 +494,15 @@ mod tests {
                                 weight: 0.5
                             }]
                             packetAttr: [{
-                                attrName: "conn-resp_pkts"
+                                rawEventKind: CONN
+                                attrName: "Packets Received"
                                 valueKind: STRING
                                 cmpKind: CONTAIN
                                 firstValue: [4, 80, 79, 83, 84]
                                 weight: 0.5
                             }, {
-                                attrName: "conn-resp_pkts"
+                                rawEventKind: CONN
+                                attrName: "Packets Received"
                                 valueKind: INTEGER
                                 cmpKind: GREATER
                                 firstValue: [251, 88, 2]


### PR DESCRIPTION
- Add `raw_event_kind` field to `PacketAttrInput` and `PacketAttr`.
- Add `UInteger`, `Vector`, `IpAddr`, `Bool` variants to `ValueKind` enum.

Close: #459

- Triage GraphQL API Test
  - Insert triage & result
    <img width="776" alt="스크린샷 2025-06-16 오후 4 04 57" src="https://github.com/user-attachments/assets/d1d74afa-0b9c-4167-ac3a-7a8283cbbd6d" />
    <img width="314" alt="스크린샷 2025-06-16 오후 4 14 35" src="https://github.com/user-attachments/assets/d0816b7f-a63c-4357-8d72-a4a945c77966" />
  - Update Triage & result
     <img width="263" alt="스크린샷 2025-06-16 오후 4 15 31" src="https://github.com/user-attachments/assets/dbe67494-fcc3-4635-b32e-61fa87889e0a" />
     <img width="297" alt="스크린샷 2025-06-16 오후 4 15 49" src="https://github.com/user-attachments/assets/71412c01-edb5-421b-bb93-e5afbbb21775" />