### PR TITLE
Modify the code related to node management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,25 @@ this project adheres to
   - This changes affects GraphQL APIs such as `insertTriagePolicy`,
     `updateTriagePolicy` , `triagePolicyList`, and `triagePolicy`. They may
     introduce breaking changes for clients relying on the previous GraphQL schema.
+- Modified code related to node management. The review-database has introduced
+  the concept of "external service" to clearly distinguish applications that
+  provide an API for interaction and operate outside the REview agent ecosystem,
+  from directly connected agents over QUIC. To reflect this concept, the
+  node-related code has been updated accordingly.
+  - Added new structs `ExternalService` and `ExternalServiceSnapshot`, along
+    with enums `ExternalServiceStatus` and `ExternalServiceKind`, to represent
+    configuration for external services. The previously used `Giganto` struct,
+    which was responsible for storing configuration for the DataStore, has been
+    removed and replaced by `ExternalService`.
+  - Replaced the `giganto` field of type `Option<GigantoInput>` in both
+    `NodeInput` and `NodeDraftInput` with an `external_services` field of type
+    `Vec<ExternalServiceInput>`. The `GigantoInput` struct, which was limited to
+    handling input for the DataStore only, has been removed. Configuration input
+    for all external services—including DataStore—is now provided through `ExternalServiceInput`.
+  - Breaking changes have been introduced in the GraphQL APIs (`nodeStatusList`,
+    `nodeList`, `node`, `insertNode`, `updateNodeDraft`, `applyNode`). So
+    clients that use the affected APIs may need to update their code to maintain
+    compatibility.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "9b18f272" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "d994135" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -1016,7 +1016,7 @@ fn convert_sensors(map: &database::NodeTable, sensors: &[ID]) -> anyhow::Result<
             .as_str()
             .parse::<u32>()
             .context(format!("invalid ID: {}", id.as_str()))?;
-        let Some((node, _invalid_agents)) = map.get_by_id(i)? else {
+        let Some((node, _invalid_agents, _invalid_external_services)) = map.get_by_id(i)? else {
             bail!("no such sensor")
         };
 
@@ -1323,8 +1323,8 @@ mod tests {
                             key: "sensor"
                             kind: SENSOR
                             status: ENABLED
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: [],
                     )
                 }"#,
             )
@@ -1351,6 +1351,7 @@ mod tests {
                                     status: "ENABLED"
                                 }
                             ],
+                            externalServices: []
                         }
                     )
                 }"#,

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -94,7 +94,7 @@ impl NodeControlMutation {
         if let Some(ref target_agents) = apply_scope.agents {
             let store = crate::graphql::get_store(ctx).await?;
             let node_map = store.node_map();
-            let (node, _) = node_map
+            let (node, _, _) = node_map
                 .get_by_id(i)?
                 .ok_or_else(|| async_graphql::Error::new(format!("Node with ID {i} not found")))?;
             let hostname = node.profile.map(|p| p.hostname).unwrap_or_default();
@@ -343,8 +343,8 @@ mod tests {
                             kind: SENSOR
                             status: ENABLED
                             draft: "test = 'toml'"
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                     )
                 }"#,
             )
@@ -380,7 +380,10 @@ mod tests {
                                 config
                                 draft
                             }
-                            giganto {
+                            externalServices {
+                                node
+                                key
+                                kind
                                 status
                                 draft
                             }
@@ -425,7 +428,7 @@ mod tests {
                                       "draft": "test = 'toml'"
                                     }
                                   ],
-                                "giganto": null,
+                                "externalServices": []
                             }
                         }
                     ]
@@ -464,7 +467,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,
@@ -501,7 +504,10 @@ mod tests {
                                 config
                                 draft
                             }
-                            giganto {
+                            externalServices {
+                                node
+                                key
+                                kind
                                 status
                                 draft
                             }
@@ -550,7 +556,7 @@ mod tests {
                                       "draft": "test = 'toml'"
                                     }
                                   ],
-                                "giganto": null,
+                                "externalServices": []
                             }
                         }
                     ]
@@ -593,7 +599,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null,
+                            externalServices: [],
                         },
                         new: {
                             nameDraft: "admin node with new name",
@@ -616,7 +622,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null,
+                            externalServices: null,
                         }
                     )
                 }"#,
@@ -653,7 +659,10 @@ mod tests {
                                 config
                                 draft
                             }
-                            giganto {
+                            externalServices {
+                                node
+                                key
+                                kind
                                 status
                                 draft
                             }
@@ -703,7 +712,7 @@ mod tests {
                                       "draft": "test = 'toml'"
                                     }
                                   ],
-                                "giganto": null,
+                                "externalServices": []
                             }
                         }
                     ]
@@ -746,7 +755,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,
@@ -783,7 +792,10 @@ mod tests {
                                 config
                                 draft
                             }
-                            giganto {
+                            externalServices {
+                                node
+                                key
+                                kind
                                 status
                                 draft
                             }
@@ -832,7 +844,7 @@ mod tests {
                                       "draft": "test = 'toml'"
                                     }
                                 ],
-                                "giganto": null
+                                "externalServices": []
                             }
                         }
                     ]
@@ -840,7 +852,7 @@ mod tests {
             })
         );
 
-        // update giganto draft
+        // update data store draft
         let res = schema
             .execute(
                 r#"mutation {
@@ -875,7 +887,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null,
+                            externalServices: []
                         },
                         new: {
                             nameDraft: "admin node with new name",
@@ -898,10 +910,14 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: {
-                                status: ENABLED,
-                                draft: "test = 'giganto_toml'"
-                            }
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
+                                    status: ENABLED,
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ]
                         }
                     )
                 }"#,
@@ -945,10 +961,14 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: {
-                                status: ENABLED,
-                                draft: "test = 'giganto_toml'"
-                            }
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
+                                    status: ENABLED,
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ]
                         }
                     )
                 }"#,
@@ -986,7 +1006,10 @@ mod tests {
                                     config
                                     draft
                                 }
-                                giganto {
+                                externalServices {
+                                    node
+                                    key
+                                    kind
                                     status
                                     draft
                                 }
@@ -1036,10 +1059,15 @@ mod tests {
                                         "draft": "test = 'toml'"
                                     }
                                 ],
-                                "giganto": {
-                                    "status": "ENABLED",
-                                    "draft": "test = 'giganto_toml'"
-                                }
+                                "externalServices": [
+                                    {
+                                        "node": 0,
+                                        "key": "data_store",
+                                        "kind": "DATA_STORE",
+                                        "status": "ENABLED",
+                                        "draft": "test = 'data_store_toml'"
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -1082,10 +1110,14 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: {
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
                                     status: ENABLED,
-                                    draft: "test = 'giganto_toml'"
-                            }
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ],
                         },
                         new: {
                             nameDraft: "admin node with new name",
@@ -1108,10 +1140,14 @@ mod tests {
                                     draft: "test = 'changed_toml'"
                                 }
                             ],
-                            giganto: {
-                                status: ENABLED,
-                                draft: "test = 'giganto_toml'"
-                            }
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
+                                    status: ENABLED,
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ],
                         }
                     )
                 }"#,
@@ -1149,7 +1185,10 @@ mod tests {
                                 config
                                 draft
                             }
-                            giganto {
+                            externalServices {
+                                node
+                                key
+                                kind
                                 status
                                 draft
                             }
@@ -1199,10 +1238,15 @@ mod tests {
                                       "draft": "test = 'changed_toml'"
                                     }
                                   ],
-                                "giganto": {
-                                    "status": "ENABLED",
-                                    "draft": "test = 'giganto_toml'"
-                                },
+                                "externalServices": [
+                                    {
+                                        "node": 0,
+                                        "key": "data_store",
+                                        "kind": "DATA_STORE",
+                                        "status": "ENABLED",
+                                        "draft": "test = 'data_store_toml'"
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -1245,10 +1289,14 @@ mod tests {
                                     draft: "test = 'changed_toml'"
                                 }
                             ],
-                            giganto: {
-                                status: ENABLED,
-                                draft: "test = 'giganto_toml'"
-                            }
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
+                                    status: ENABLED,
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ]
                         }
                     )
                 }"#,
@@ -1286,7 +1334,10 @@ mod tests {
                                     config
                                     draft
                                 }
-                                giganto {
+                                externalServices {
+                                    node
+                                    key
+                                    kind
                                     status
                                     draft
                                 }
@@ -1336,10 +1387,15 @@ mod tests {
                                         "draft": "test = 'changed_toml'"
                                     }
                                 ],
-                                "giganto": {
-                                    "status": "ENABLED",
-                                    "draft": "test = 'giganto_toml'"
-                                }
+                                "externalServices": [
+                                    {
+                                        "node": 0,
+                                        "key": "data_store",
+                                        "kind": "DATA_STORE",
+                                        "status": "ENABLED",
+                                        "draft": "test = 'data_store_toml'"
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -1382,10 +1438,14 @@ mod tests {
                                     draft: "test = 'changed_toml'"
                                 }
                             ],
-                            giganto: {
-                                status: "ENABLED",
-                                draft: "test = 'giganto_toml'"
-                            }
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
+                                    status: ENABLED,
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ]
                         },
                         new: {
                             nameDraft: "admin node with new name",
@@ -1408,10 +1468,14 @@ mod tests {
                                     draft: null
                                 }
                             ],
-                            giganto: {
-                                status: "ENABLED",
-                                draft: "test = 'giganto_toml'"
-                            }
+                            externalServices: [
+                                {
+                                    key: "data_store",
+                                    kind: DATA_STORE,
+                                    status: ENABLED,
+                                    draft: "test = 'data_store_toml'"
+                                }
+                            ]
                         }
                     )
                 }"#,
@@ -1449,7 +1513,10 @@ mod tests {
                                 config
                                 draft
                             }
-                            giganto {
+                            externalServices {
+                                node
+                                key
+                                kind
                                 status
                                 draft
                             }
@@ -1499,10 +1566,15 @@ mod tests {
                                       "draft": null
                                     }
                                   ],
-                                "giganto": {
-                                    "status": "ENABLED",
-                                    "draft": "test = 'giganto_toml'"
-                                },
+                                "externalServices": [
+                                    {
+                                        "node": 0,
+                                        "key": "data_store",
+                                        "kind": "DATA_STORE",
+                                        "status": "ENABLED",
+                                        "draft": "test = 'data_store_toml'"
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -1546,10 +1618,14 @@ mod tests {
                                         draft: null
                                     }
                                 ],
-                                giganto: {
-                                    status: "ENABLED",
-                                    draft: "test = 'giganto_toml'"
-                                }
+                                externalServices: [
+                                    {
+                                        key: "data_store",
+                                        kind: DATA_STORE,
+                                        status: ENABLED,
+                                        draft: "test = 'data_store_toml'"
+                                    }
+                                ]
                             }
                         )
                     }"#,
@@ -1586,7 +1662,10 @@ mod tests {
                                     config
                                     draft
                                 }
-                                giganto {
+                                externalServices {
+                                    node
+                                    key
+                                    kind
                                     status
                                     draft
                                 }
@@ -1628,10 +1707,15 @@ mod tests {
                                       "draft": "test = 'toml'"
                                     }
                                 ],
-                                "giganto": {
-                                    "status": "ENABLED",
-                                    "draft": "test = 'giganto_toml'"
-                                }
+                                "externalServices": [
+                                    {
+                                        "node": 0,
+                                        "key": "data_store",
+                                        "kind": "DATA_STORE",
+                                        "status": "ENABLED",
+                                        "draft": "test = 'data_store_toml'"
+                                    }
+                                ]
                             }
                         }
                     ]
@@ -1667,7 +1751,7 @@ mod tests {
                             status: ENABLED
                             draft: ""
                         }]
-                        giganto: null
+                        externalServices: []
                     )
                 }"#,
             )
@@ -1698,7 +1782,7 @@ mod tests {
                                         draft: ""
                                     }
                                 ],
-                                giganto: null
+                                externalServices: []
                             }
                         )
                     }"#,
@@ -1735,7 +1819,10 @@ mod tests {
                                     config
                                     draft
                                 }
-                                giganto {
+                                externalServices {
+                                    node
+                                    key
+                                    kind
                                     status
                                     draft
                                 }
@@ -1776,7 +1863,7 @@ mod tests {
                                       "draft": ""
                                     }
                                   ],
-                                "giganto": null,
+                                "externalServices": []
                             }
                         }
                     ]
@@ -1815,7 +1902,7 @@ mod tests {
                             status: ENABLED
                             draft: "test = 'toml'"
                         }]
-                        giganto: null
+                        externalServices: []
                     )
                 }"#,
             )
@@ -1823,7 +1910,7 @@ mod tests {
         assert_eq!(res.data.to_string(), r#"{insertNode: "0"}"#);
 
         // Simulate a situation where `name_draft` is set to `None`
-        let (node, _invalid_agents) = schema
+        let (node, _, _) = schema
             .store()
             .await
             .node_map()
@@ -1868,7 +1955,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,
@@ -1909,7 +1996,7 @@ mod tests {
                             status: ENABLED
                             draft: "test = 'toml'"
                         }]
-                        giganto: null
+                        externalServices: []
                     )
                 }"#,
             )
@@ -1947,7 +2034,7 @@ mod tests {
                                     draft: "test = 'different_toml'"
                                 }
                             ],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,
@@ -1988,7 +2075,7 @@ mod tests {
                             status: ENABLED
                             draft: "test = 'toml'"
                         }]
-                        giganto: null
+                        externalServices: []
                     )
                 }"#,
             )
@@ -2026,7 +2113,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,
@@ -2066,7 +2153,7 @@ mod tests {
                             status: ENABLED
                             draft: "test = 'toml'"
                         }]
-                        giganto: null
+                        externalServices: []
                     )
                 }"#,
             )
@@ -2104,7 +2191,7 @@ mod tests {
                                     draft: "test = 'toml'"
                                 }
                             ],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -243,8 +243,8 @@ mod tests {
                             status: ENABLED
                             draft: "my_val=1"
                         }}
-                    ]
-                    giganto: null
+                    ],
+                    externalServices: []
                 )
             }}"#
         );
@@ -274,7 +274,7 @@ mod tests {
                                         config: null
                                         draft: "my_val=1"
                                     }}],
-                                giganto: null
+                                externalServices: []
                             }}
                         )
                     }}"#
@@ -303,8 +303,8 @@ mod tests {
                             kind: SEMI_SUPERVISED
                             status: ENABLED
                             draft: "my_val=2"
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                     )
                 }"#,
             )
@@ -339,7 +339,7 @@ mod tests {
                                 config: null
                                 draft: "my_val=2"
                             }],
-                            giganto: null
+                            externalServices: []
                         }
                     )
                 }"#,
@@ -366,7 +366,6 @@ mod tests {
                                     description
                                     hostname
                                 }
-                                gigantoDraft
                                 cpuUsage
                                 totalMemory
                                 usedMemory
@@ -378,6 +377,11 @@ mod tests {
                                     kind
                                     storedStatus
                                     config
+                                    draft
+                                }
+                                externalServices {
+                                    kind
+                                    storedStatus
                                     draft
                                 }
                             }
@@ -406,7 +410,6 @@ mod tests {
                                     "description": "This node has the Manager.",
                                     "hostname": manager_hostname
                                 },
-                                "gigantoDraft": null,
                                 "ping": 0.0,
                                 "manager": true,
                                 "agents": [
@@ -416,7 +419,8 @@ mod tests {
                                         "config": "my_val=1",
                                         "draft": "my_val=1",
                                     }
-                                ]
+                                ],
+                                "externalServices": [],
                             }
                         },
                         {
@@ -433,7 +437,6 @@ mod tests {
                                     "description": "This is the node for the Unsupervised and the Semi-supervised module.",
                                     "hostname": "analysis"
                                 },
-                                "gigantoDraft": null,
                                 "cpuUsage": 20.0,
                                 "totalMemory": "1000",
                                 "usedMemory": "100",
@@ -454,7 +457,8 @@ mod tests {
                                         "config": "my_val=2",
                                         "draft": "my_val=2"
                                     }
-                                ]
+                                ],
+                                "externalServices": [],
                             }
                         }
                     ]
@@ -498,8 +502,8 @@ mod tests {
                             key: "semi-supervised"
                             kind: SEMI_SUPERVISED
                             status: ENABLED
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                     )
                 }"#,
             )
@@ -523,8 +527,8 @@ mod tests {
                             key: "semi-supervised"
                             kind: SEMI_SUPERVISED
                             status: ENABLED
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                     )
                 }"#,
             )
@@ -548,8 +552,8 @@ mod tests {
                             key: "semi-supervised"
                             kind: SEMI_SUPERVISED
                             status: ENABLED
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                     )
                 }"#,
             )
@@ -573,8 +577,8 @@ mod tests {
                             key: "semi-supervised"
                             kind: SEMI_SUPERVISED
                             status: ENABLED
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                         )
                     }"#,
             )
@@ -593,8 +597,8 @@ mod tests {
                             key: "sensor1@collector"
                             kind: SENSOR
                             status: ENABLED
-                        }]
-                        giganto: null
+                        }],
+                        externalServices: []
                     )
             }"#,
             )


### PR DESCRIPTION
- Add `ExternalService`, `ExternalServiceSnapshot` structs and related enums(`ExternalServiceStatus`, `ExternalServiceKind`).
- Replace `Option<GigantoInput>` with `Vec<ExternalServiceInput>` in `NodeInput` and `NodeDraftInput`.
- Remove `Giganto` and `GigantoInput` structs.

Close: #398

- node management GraphQL API Test
  - insertNode & result
     <img width="504" alt="image" src="https://github.com/user-attachments/assets/03c94133-2ab0-4654-bf29-124c4aa17246" />
      <img width="614" alt="image" src="https://github.com/user-attachments/assets/c20e52e2-7261-4a3c-b455-27d0e82f5dca" />
  - applyNode & result
     <img width="528" alt="image" src="https://github.com/user-attachments/assets/ab418c64-0030-4772-9827-83c4f71787b4" />
     <img width="665" alt="image" src="https://github.com/user-attachments/assets/9c0d15b6-1325-4e71-8bf4-6152c6743024" />
  - updateDraftNode + applyNode & result
     <img width="882" alt="image" src="https://github.com/user-attachments/assets/3f523ae2-0139-4a2b-8cd1-97c1d239d974" />
     <img width="843" alt="image" src="https://github.com/user-attachments/assets/37fb0f55-69e2-46b0-b458-a8afd08418aa" />
     <img width="571" alt="image" src="https://github.com/user-attachments/assets/ac003136-7cb8-42fe-8fff-b00f3a1a6d06" />




