### PR TITLE
Refactor log messages for consistency and clarity

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -408,7 +408,7 @@ where
 
     for node in &nodes {
         let Err(e) = node else { continue };
-        warn!("failed to load account: {}", e);
+        warn!("Failed to load from DB: {}", e);
         return Err("database error".into());
     }
 

--- a/src/graphql/cert.rs
+++ b/src/graphql/cert.rs
@@ -5,6 +5,7 @@ use tokio::sync::Notify;
 use tracing::info;
 
 use super::{CertManager, Role, RoleGuard};
+use crate::info_with_username;
 
 #[derive(Debug, SimpleObject)]
 struct CertificatePayload {
@@ -31,7 +32,10 @@ impl CertMutation {
         cert: String,
         key: String,
     ) -> Result<CertificatePayload> {
-        info!("Received a request to update certificate and private key");
+        info_with_username!(
+            ctx,
+            "Received a request to update certificate and private key"
+        );
 
         let cert_manager = ctx.data::<Arc<dyn CertManager>>()?;
         let parsed_certs = cert_manager.update_certificate(cert, key)?;

--- a/src/graphql/customer.rs
+++ b/src/graphql/customer.rs
@@ -14,6 +14,7 @@ use tracing::error;
 
 use super::node::SEMI_SUPERVISED_AGENT;
 use super::{BoxedAgentManager, Role, RoleGuard, agent_keys_by_customer_id};
+use crate::error_with_username;
 use crate::graphql::query_with_constraints;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -177,7 +178,7 @@ impl CustomerMutation {
             if let Err(e) =
                 send_agent_specific_customer_networks(ctx, &removed_customer_networks).await
             {
-                error!("failed to broadcast internal networks. {e:?}");
+                error_with_username!(ctx, "Failed to broadcast internal networks: {e:?}");
             }
         }
 
@@ -221,7 +222,7 @@ impl CustomerMutation {
                 );
 
                 if let Err(e) = send_agent_specific_customer_networks(ctx, &[network_list]).await {
-                    error!("failed to broadcast internal networks. {e:?}");
+                    error_with_username!(ctx, "Failed to broadcast internal networks: {e:?}");
                 }
             }
         }

--- a/src/graphql/event/group.rs
+++ b/src/graphql/event/group.rs
@@ -7,7 +7,10 @@ use review_database::{self as database, Direction, Event, EventFilter};
 use tracing::warn;
 
 use super::{EventListFilterInput, from_filter_input};
-use crate::graphql::{Role, RoleGuard};
+use crate::{
+    graphql::{Role, RoleGuard},
+    warn_with_username,
+};
 
 #[derive(Default)]
 pub(in crate::graphql) struct EventGroupQuery;
@@ -254,7 +257,7 @@ impl EventGroupQuery {
             let (key, event) = match item {
                 Ok(kv) => kv,
                 Err(e) => {
-                    warn!("invalid event: {:?}", e);
+                    warn_with_username!(ctx, "Invalid event: {:?}", e);
                     continue;
                 }
             };
@@ -322,7 +325,7 @@ async fn count_events<T>(
         let (key, event) = match item {
             Ok(kv) => kv,
             Err(e) => {
-                warn!("invalid event: {:?}", e);
+                warn_with_username!(ctx, "Invalid event: {:?}", e);
                 continue;
             }
         };
@@ -375,7 +378,7 @@ async fn count_events_by_network(
         let (key, event) = match item {
             Ok(kv) => kv,
             Err(e) => {
-                warn!("invalid event: {:?}", e);
+                warn_with_username!(ctx, "Invalid event: {:?}", e);
                 continue;
             }
         };


### PR DESCRIPTION
Closes: #518 

Note:
Retrieved `username` value from `ctx` for logging purpose.
Future logs will follow the same pattern to include usernames where applicable.