### PR TITLE
Add confidence field to TidbRule GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ this project adheres to
 - Implemented account lockout functionality for failed login attempts. Accounts
   are locked for 30 minutes after 5 consecutive failed login attempts to prevent
   brute force attacks.
+- Added `confidence` field to `TidbRule` GraphQL API.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ this project adheres to
 - Implemented account lockout functionality for failed login attempts. Accounts
   are locked for 30 minutes after 5 consecutive failed login attempts to prevent
   brute force attacks.
-- Added `confidence` field to `TidbRule` GraphQL API.
+- Added `confidence` field to `tidbRule` GraphQL API.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "06cc489" }
+review-database = { git = "https://github.com/petabi/review-database.git", rev = "ea5bd6e" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -140,7 +140,7 @@ impl NodeMutation {
             external_services,
             creation_time: Utc::now(),
         };
-        let id = map.put(value)?;
+        let id = map.put(&value)?;
         Ok(ID(id.to_string()))
     }
 

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -534,7 +534,6 @@ mod tests {
             )
             .await;
         assert_eq!(res.data.to_string(), "null");
-        // assert_eq!(res.data.to_string(), r#"{insertNode: "1"}"#);
 
         let res = schema
             .execute(

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -533,7 +533,8 @@ mod tests {
                 }"#,
             )
             .await;
-        assert_eq!(res.data.to_string(), r#"{insertNode: "1"}"#);
+        assert_eq!(res.data.to_string(), "null");
+        // assert_eq!(res.data.to_string(), r#"{insertNode: "1"}"#);
 
         let res = schema
             .execute(
@@ -542,7 +543,7 @@ mod tests {
                         name: "test3",
                         customerId: 0,
                         description: "This node has the Unsupervised and the Semi-supervised.",
-                        hostname: "admin.aice-security.com",
+                        hostname: "admin3.aice-security.com",
                         agents: [{
                             key: "unsupervised"
                             kind: UNSUPERVISED
@@ -558,7 +559,7 @@ mod tests {
                 }"#,
             )
             .await;
-        assert_eq!(res.data.to_string(), r#"{insertNode: "2"}"#);
+        assert_eq!(res.data.to_string(), r#"{insertNode: "1"}"#);
 
         let res = schema
             .execute(
@@ -567,7 +568,7 @@ mod tests {
                         name: "test4",
                         customerId: 0,
                         description: "This node has the Unsupervised and the Semi-supervised.",
-                        hostname: "admin.aice-security.com",
+                        hostname: "admin4.aice-security.com",
                         agents: [{
                             key: "unsupervised"
                             kind: UNSUPERVISED
@@ -583,7 +584,7 @@ mod tests {
                     }"#,
             )
             .await;
-        assert_eq!(res.data.to_string(), r#"{insertNode: "3"}"#);
+        assert_eq!(res.data.to_string(), r#"{insertNode: "2"}"#);
 
         let res = schema
             .execute(
@@ -592,7 +593,7 @@ mod tests {
                         name: "test5",
                         customerId: 0,
                         description: "This node has the Sensor.",
-                        hostname: "admin.aice-security.com",
+                        hostname: "admin5.aice-security.com",
                         agents: [{
                             key: "sensor1@collector"
                             kind: SENSOR
@@ -603,14 +604,14 @@ mod tests {
             }"#,
             )
             .await;
-        assert_eq!(res.data.to_string(), r#"{insertNode: "4"}"#);
+        assert_eq!(res.data.to_string(), r#"{insertNode: "3"}"#);
 
         let res = schema
             .execute(r"{nodeStatusList(first:5){edges{node{name}}}}")
             .await;
         assert_eq!(
             res.data.to_string(),
-            r#"{nodeStatusList: {edges: [{node: {name: "test1"}}, {node: {name: "test2"}}, {node: {name: "test3"}}, {node: {name: "test4"}}, {node: {name: "test5"}}]}}"#
+            r#"{nodeStatusList: {edges: [{node: {name: "test1"}}, {node: {name: "test3"}}, {node: {name: "test4"}}, {node: {name: "test5"}}]}}"#
         );
 
         let res = schema
@@ -618,7 +619,7 @@ mod tests {
             .await;
         assert_eq!(
             res.data.to_string(),
-            r#"{nodeStatusList: {edges: [{node: {name: "test1"}}, {node: {name: "test2"}}, {node: {name: "test3"}}, {node: {name: "test4"}}, {node: {name: "test5"}}], pageInfo: {endCursor: "WzExNiwxMDEsMTE1LDExNiw1M10"}}}"#
+            r#"{nodeStatusList: {edges: [{node: {name: "test1"}}, {node: {name: "test3"}}, {node: {name: "test4"}}, {node: {name: "test5"}}], pageInfo: {endCursor: "WzExNiwxMDEsMTE1LDExNiw1M10"}}}"#
         );
 
         let res = schema
@@ -626,7 +627,7 @@ mod tests {
             .await;
         assert_eq!(
             res.data.to_string(),
-            r#"{nodeStatusList: {edges: [{node: {name: "test1"}}, {node: {name: "test2"}}], pageInfo: {startCursor: "WzExNiwxMDEsMTE1LDExNiw0OV0"}}}"#
+            r#"{nodeStatusList: {edges: [{node: {name: "test1"}}], pageInfo: {startCursor: "WzExNiwxMDEsMTE1LDExNiw0OV0"}}}"#
         );
 
         let res = schema

--- a/src/graphql/tidb.rs
+++ b/src/graphql/tidb.rs
@@ -218,6 +218,10 @@ impl TidbRule {
     async fn signatures(&self) -> &Option<Vec<String>> {
         &self.inner.signatures
     }
+
+    async fn confidence(&self) -> Option<f32> {
+        self.inner.confidence
+    }
 }
 
 impl From<database::TidbRule> for TidbRule {


### PR DESCRIPTION
Close: #525 

- Added `confidence` field to TidbRule struct.
- Fixed test code to check duplicate of node hostname.
   [Enforce unique hostnames for nodes](https://github.com/petabi/review-database/commit/3fea24c6bfeaf3cc827a44335b957ffa90d9f7ef)

Pending:
- [x] https://github.com/petabi/review-database/pull/501
- [x] #540