### PR TITLE
Add logs for audit purposes

### DIFF
--- a/src/graphql/db_management.rs
+++ b/src/graphql/db_management.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use async_graphql::{Context, Object, Result};
 use review_database::{Store, backup};
 use tokio::sync::RwLock;
+use tracing::info;
 
 use super::{Role, RoleGuard};
+use crate::info_with_username;
 
 #[derive(Default)]
 pub(super) struct DbManagementMutation;
@@ -15,6 +17,7 @@ impl DbManagementMutation {
         .or(RoleGuard::new(Role::SecurityAdministrator))")]
     async fn backup(&self, ctx: &Context<'_>, num_of_backups_to_keep: u32) -> Result<bool> {
         let store = ctx.data::<Arc<RwLock<Store>>>()?;
+        info_with_username!(ctx, "Database backup is being executed");
         Ok(backup::create(store, false, num_of_backups_to_keep)
             .await
             .is_ok())
@@ -24,6 +27,7 @@ impl DbManagementMutation {
         .or(RoleGuard::new(Role::SecurityAdministrator))")]
     async fn restore_from_latest_backup(&self, ctx: &Context<'_>) -> Result<bool> {
         let store = ctx.data::<Arc<RwLock<Store>>>()?;
+        info_with_username!(ctx, "Database is being restored from the latest backup");
         backup::restore(store, None).await?;
         Ok(true)
     }

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -22,8 +22,10 @@ impl NodeControlMutation {
         let agents = ctx.data::<BoxedAgentManager>()?;
         let review_hostname = roxy::hostname();
         if !review_hostname.is_empty() && review_hostname == hostname {
+            info_with_username!(ctx, "Node reboot skipped: manager is running on {hostname}");
             Err("cannot reboot. review reboot is not allowed".into())
         } else {
+            info_with_username!(ctx, "Reboot request sent to {hostname}");
             agents.reboot(&hostname).await?;
             Ok(hostname)
         }
@@ -35,8 +37,13 @@ impl NodeControlMutation {
         let agents = ctx.data::<BoxedAgentManager>()?;
         let review_hostname = roxy::hostname();
         if !review_hostname.is_empty() && review_hostname == hostname {
+            info_with_username!(
+                ctx,
+                "Node shutdown skipped: manager is running on {hostname}"
+            );
             Err("cannot shutdown. review shutdown is not allowed".into())
         } else {
+            info_with_username!(ctx, "Shutdown request sent to {hostname}");
             agents.halt(&hostname).await?;
             Ok(hostname)
         }

--- a/src/graphql/node/status.rs
+++ b/src/graphql/node/status.rs
@@ -7,12 +7,14 @@ use async_graphql::{
 };
 use review_database::UniqueKey;
 use roxy::ResourceUsage;
+use tracing::info;
 
 use super::{
     super::{BoxedAgentManager, Role, RoleGuard},
     NodeStatus, NodeStatusQuery, NodeStatusTotalCount, matches_manager_hostname,
 };
 use crate::graphql::query_with_constraints;
+use crate::info_with_username;
 
 #[Object]
 impl NodeStatusQuery {
@@ -28,6 +30,7 @@ impl NodeStatusQuery {
         last: Option<i32>,
     ) -> Result<Connection<OpaqueCursor<Vec<u8>>, NodeStatus, NodeStatusTotalCount, EmptyFields>>
     {
+        info_with_username!(ctx, "Node status lookup requested");
         query_with_constraints(
             after,
             before,

--- a/src/graphql/tidb.rs
+++ b/src/graphql/tidb.rs
@@ -1,7 +1,9 @@
 use async_graphql::{Context, Enum, ID, Object, Result, SimpleObject};
 use review_database::{self as database, TidbRuleKind as DbTidbRuleKind};
+use tracing::info;
 
 use super::{Role, RoleGuard, triage::ThreatCategory};
+use crate::info_with_username;
 
 #[derive(Default)]
 pub(super) struct TidbQuery;
@@ -27,6 +29,7 @@ impl TidbQuery {
         let store = super::get_store(ctx).await?;
         let table = store.tidb_map();
 
+        info_with_username!(ctx, "TI list requested");
         Ok(table.get_list()?.into_iter().map(Into::into).collect())
     }
 
@@ -76,6 +79,7 @@ impl TidbMutation {
         let store = super::get_store(ctx).await?;
         let table = store.tidb_map();
         table.insert(tidb)?;
+        info_with_username!(ctx, "TI {} has been registered", output.name);
 
         Ok(output)
     }
@@ -99,6 +103,7 @@ impl TidbMutation {
                 Err(e) => return Err(format!("{e:?}").into()),
             }
         }
+        info_with_username!(ctx, "TI {:?} has been deleted", removed);
         Ok(removed)
     }
 
@@ -124,6 +129,8 @@ impl TidbMutation {
         let table = store.tidb_map();
 
         table.update(&name, tidb)?;
+        info_with_username!(ctx, "TI {name} has been updated to {}", output.name);
+
         Ok(output)
     }
 }

--- a/src/graphql/traffic_filter.rs
+++ b/src/graphql/traffic_filter.rs
@@ -4,8 +4,10 @@ use async_graphql::{Context, Object, Result};
 use chrono::{DateTime, Utc};
 use ipnet::IpNet;
 use review_database::{self as database};
+use tracing::info;
 
 use super::{BoxedAgentManager, Role, RoleGuard};
+use crate::info_with_username;
 
 #[derive(Default)]
 pub(super) struct TrafficFilterQuery;
@@ -87,6 +89,7 @@ impl TrafficFilterMutation {
         let store = crate::graphql::get_store(ctx).await?;
         let table = store.traffic_filter_map();
 
+        info_with_username!(ctx, "All traffic filters have been deleted");
         table.remove(&agent).map_err(Into::into).map(|()| 0)
     }
 

--- a/src/graphql/triage/response.rs
+++ b/src/graphql/triage/response.rs
@@ -5,11 +5,13 @@ use async_graphql::{
     types::ID,
 };
 use chrono::{DateTime, Utc};
+use tracing::info;
 
 use super::{Role, RoleGuard};
 use crate::graphql::{
     cluster::try_id_args_into_ints, network::id_args_into_uints, query_with_constraints,
 };
+use crate::info_with_username;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct TriageResponse {
@@ -143,6 +145,7 @@ impl super::TriageResponseMutation {
         let store = crate::graphql::get_store(ctx).await?;
         let map = store.triage_response_map();
         let id = map.put(pol)?;
+        info_with_username!(ctx, "Triage response {id} has been registered");
 
         Ok(ID(id.to_string()))
     }
@@ -164,6 +167,7 @@ impl super::TriageResponseMutation {
         for id in ids {
             let i = id.as_str().parse::<u32>().map_err(|_| "invalid ID")?;
             let _key = map.remove(i)?;
+            info_with_username!(ctx, "Triage response {i} has been deleted");
 
             removed.push(i.to_string());
         }
@@ -188,6 +192,7 @@ impl super::TriageResponseMutation {
         let old: review_database::TriageResponseUpdate = old.try_into()?;
         let new: review_database::TriageResponseUpdate = new.try_into()?;
         map.update(i, &old, &new)?;
+        info_with_username!(ctx, "Triage response {i} has been modified");
 
         Ok(id)
     }

--- a/src/graphql/trusted_domain.rs
+++ b/src/graphql/trusted_domain.rs
@@ -3,9 +3,11 @@ use async_graphql::{
     Context, InputObject, Object, Result, SimpleObject,
     connection::{Connection, EmptyFields},
 };
+use tracing::info;
 
 use super::{AgentManager, BoxedAgentManager, Role, RoleGuard};
 use crate::graphql::query_with_constraints;
+use crate::info_with_username;
 
 #[derive(Default)]
 pub(super) struct TrustedDomainQuery;
@@ -57,6 +59,7 @@ impl TrustedDomainMutation {
 
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager.broadcast_trusted_domains().await?;
+        info_with_username!(ctx, "Trusted domain {} has been registered", entry.name);
         Ok(entry.name)
     }
 
@@ -77,6 +80,12 @@ impl TrustedDomainMutation {
 
         let agent_manager = ctx.data::<BoxedAgentManager>()?;
         agent_manager.broadcast_trusted_domains().await?;
+        info_with_username!(
+            ctx,
+            "Trusted domain {} has been updated to {}",
+            old.name,
+            new.name
+        );
         Ok(new.name)
     }
 
@@ -98,6 +107,7 @@ impl TrustedDomainMutation {
             .into_iter()
             .try_fold(Vec::with_capacity(count), |mut removed, name| {
                 if map.remove(&name).is_ok() {
+                    info_with_username!(ctx, "Trusted domain {name} has been deleted");
                     removed.push(name);
                     Ok(removed)
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ where
 
             tokio::select! {
                 () = wait_shutdown => {
-                    info!("Shutting down Web server");
+                    info!("Manager GraphQL web server is stopping");
                     notify_shutdown.notify_one();
                     shutdown_completed.notified().await;
                     web_srv_shutdown_handle.notify_one();
@@ -156,7 +156,7 @@ where
         }
     });
 
-    info!("Starting Web Server");
+    info!("Manager GraphQL web server is starting");
     tokio::spawn(async {
         match server.await {
             Ok(Err(e)) => error!("Web server died: {:?}", e),


### PR DESCRIPTION
Closes: #547

Some cases from the initial draft on our private wiki are missing in the current code:
- Requests handled directly by the web UI without triggering any GraphQL calls
- Logs related to time series policies (could not locate the relevant code paths)
- Logs related to traffic filters (the name of the traffic filter could not be retrieved)
- Other functionalities that appear to be outside the scope of review-web