### PR TITLE
Use `column_stats` table in RocksDB instead of PostgresQL for retrieving related data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/petabi/review-database.git", rev = "368a966" }
+review-database = { git = "https://github.com/petabi/review-database.git", version = "0.40.0"}
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.3.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/filter.rs
+++ b/src/graphql/filter.rs
@@ -105,6 +105,7 @@ impl FilterMutation {
             kinds,
             learning_methods: learning_methods.map(|v| v.into_iter().map(Into::into).collect()),
             confidence,
+            period: database::PeriodForSearch::Recent("1 hour".to_string()), // set to default for now
         };
 
         map.insert(filter)?;
@@ -455,6 +456,7 @@ impl TryFrom<FilterInput> for database::Filter {
                 .learning_methods
                 .map(|values| values.into_iter().map(Into::into).collect()),
             confidence: input.confidence,
+            period: database::PeriodForSearch::Recent("1 hour".to_string()), // set to default for now
         })
     }
 }


### PR DESCRIPTION
Note that `Filter::period` is set to default period used by review-database: `database::PeriodForSearch::Recent("1 hour".to_string())`. This should be replaced with the period specified by the user once the UI supports it.