### PR TITLE
Serialize `sign_in_with_new_password_proceed` test

### DIFF
--- a/src/graphql/account.rs
+++ b/src/graphql/account.rs
@@ -3162,6 +3162,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn sign_in_with_new_password_proceed() {
         let schema = TestSchema::new().await;
         let res = schema


### PR DESCRIPTION
## Description
Run `sign_in_with_new_password_proceed` under `#[serial]` so it no longer races with tests that force Aimer-token failures. Document the stability fix in `CHANGELOG.md` for visibility in release notes.

Closes: #691