### PR TITLE
Add MtlsAuthenticator trait and refactor handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rcgen = "0.14"
 serial_test = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "signal", "sync"] }
+tokio-tungstenite = "0.28"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,7 +8,7 @@ mod store;
 #[cfg(all(test, feature = "auth-jwt"))]
 pub(crate) use jwt::ForceAimerTokenFailureGuard;
 #[cfg(feature = "auth-mtls")]
-pub use mtls::{MtlsAuthError, validate_client_cert, validate_context_jwt};
+pub use mtls::{MtlsAuthError, MtlsAuthenticator, MtlsIdentity, validate_context_jwt};
 #[cfg(feature = "auth-jwt")]
 pub use {
     jwt::{


### PR DESCRIPTION
Define MtlsIdentity and MtlsAuthenticator trait in auth::mtls for dependency-inversion: the trait lives in review-web while the implementation will be injected from the review crate.

- Add authenticator field to ServerConfig (auth-mtls only)
- Refactor graphql_handler and graphql_ws_handler to call authenticator.authenticate() instead of validate_client_cert()
- Remove validate_client_cert(), has_service_name(), and related SAN validation code and constants
- Add integration tests: missing Authorization header, non-admin with customer_ids, identity field parsing, WebSocket happy path and auth rejection with timeouts

Closes #790
Closes #791 
Closes #792