### PR TITLE
Scope local auth bypass to auth-jwt only (#840)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `comprehensiveUserList` now reports `isLocked` based on the account's
   current temporary-lock expiry and `isSuspended` from the account's
   suspension state, rather than deriving both from a single flag.
+- Scoped `REVIEW_WEB_DISABLE_LOCAL_AUTH_BYPASS` and the `is_local`
+  loopback-bypass plumbing to the `auth-jwt` build only. Under `auth-mtls`
+  the env var is now a no-op; loopback callers are subject to the same
+  mTLS peer-cert + JWT validation as any other peer. Operators who set
+  this env as a workaround can drop it after upgrade. `auth-jwt`
+  semantics are unchanged.
 
 ## [0.31.0] - 2026-04-18
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -849,6 +849,10 @@ where
 #[derive(Debug, PartialEq)]
 pub(crate) enum RoleGuard {
     Role(database::Role),
+    // The `Local` variant is constructed only by the `auth-jwt` loopback bypass
+    // in `lib.rs`, but is referenced as a guard in resolvers that compile under
+    // both feature flags.
+    #[cfg_attr(not(feature = "auth-jwt"), allow(dead_code))]
     Local,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,11 @@ use async_graphql::{
     http::{GraphQLPlaygroundConfig, playground_source},
 };
 use async_graphql_axum::{GraphQLProtocol, GraphQLRequest, GraphQLResponse, GraphQLWebSocket};
+#[cfg(feature = "auth-jwt")]
+use axum::extract::ConnectInfo;
 use axum::{
     Json, Router,
-    extract::{ConnectInfo, Extension, WebSocketUpgrade},
+    extract::{Extension, WebSocketUpgrade},
     response::{Html, IntoResponse, Response},
     routing::{get, get_service},
 };
@@ -73,6 +75,7 @@ const ERR_MTLS_REQUIRED: &str = "mTLS is required";
 const ERR_MTLS_MISSING_CERT: &str = "mTLS client certificate is missing";
 #[cfg(feature = "auth-mtls")]
 const ERR_MISSING_AUTHORIZATION: &str = "Missing Authorization";
+#[cfg(feature = "auth-jwt")]
 const DISABLE_LOCAL_AUTH_BYPASS_ENV: &str = "REVIEW_WEB_DISABLE_LOCAL_AUTH_BYPASS";
 
 /// Parameters for a web server.
@@ -365,6 +368,7 @@ async fn graphql_playground() -> Result<impl IntoResponse, Error> {
     )))
 }
 
+#[cfg(feature = "auth-jwt")]
 fn is_local(addr: SocketAddr) -> bool {
     if std::env::var_os(DISABLE_LOCAL_AUTH_BYPASS_ENV).is_some() {
         return false;
@@ -412,19 +416,11 @@ async fn graphql_handler(
     Extension(schema): Extension<graphql::Schema>,
     Extension(_store): Extension<Arc<RwLock<Store>>>,
     Extension(authenticator): Extension<Arc<dyn MtlsAuthenticator>>,
-    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     peer: Option<Extension<Arc<TlsPeerInfo>>>,
     auth: Result<TypedHeader<Authorization<Bearer>>, TypedHeaderRejection>,
     request: GraphQLRequest,
 ) -> Result<GraphQLResponse, Error> {
     let request = request.into_inner();
-    if is_local(addr) {
-        return Ok(schema
-            .execute(request.data(RoleGuard::Local).data(addr))
-            .await
-            .into());
-    }
-
     let peer = peer
         .map(|Extension(p)| p)
         .ok_or_else(|| Error::Unauthorized(ERR_MTLS_REQUIRED.to_string()))?;
@@ -490,7 +486,6 @@ async fn graphql_ws_handler(
     Extension(authenticator): Extension<Arc<dyn MtlsAuthenticator>>,
     protocol: GraphQLProtocol,
     websocket: WebSocketUpgrade,
-    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     peer: Option<Extension<Arc<TlsPeerInfo>>>,
 ) -> Response {
     let peer = peer.map(|Extension(p)| p);
@@ -509,12 +504,6 @@ async fn graphql_ws_handler(
                             auth: String,
                         }
                         let mut data = Data::default();
-
-                        if is_local(addr) {
-                            data.insert(RoleGuard::Local);
-                            data.insert(addr);
-                            return Ok(data);
-                        }
 
                         let peer =
                             peer.ok_or_else(|| async_graphql::Error::new(ERR_MTLS_REQUIRED))?;

--- a/tests/mtls_integration.rs
+++ b/tests/mtls_integration.rs
@@ -42,6 +42,7 @@ mod mtls_integration {
     const ERR_SAN_SERVICE_MISMATCH: &str = "Client certificate SAN does not match service name";
     const ERR_JWT_ALG_EC_MISMATCH: &str = "JWT algorithm does not match EC key";
     const ERR_MISSING_CUSTOMER_IDS: &str = "Missing customer_ids claim for non-admin role";
+    const ERR_MTLS_REQUIRED: &str = "mTLS is required";
     const WS_RECV_TIMEOUT: Duration = Duration::from_secs(5);
     // Fixed RSA private key used only to produce an RS256 JWT for alg-mismatch tests.
     const RSA_PRIVATE_KEY_PEM: &str = r"-----BEGIN PRIVATE KEY-----
@@ -318,10 +319,6 @@ xvcNsYaYqk6sRk/INvcaN2E=
     }
 
     fn start_test_server() -> anyhow::Result<TestServer> {
-        // SAFETY: test-only environment override for auth bypass is scoped to this process.
-        unsafe {
-            std::env::set_var("REVIEW_WEB_DISABLE_LOCAL_AUTH_BYPASS", "1");
-        }
         let addr_ip = LOCALHOST_IP;
         let port = {
             let listener =
@@ -544,6 +541,14 @@ xvcNsYaYqk6sRk/INvcaN2E=
         let client = build_client_without_identity(&server.ca_cert)?;
         let response = send_graphql_request(&client, &server.url, None).await?;
         assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.context("read response body")?)
+                .context("parse response JSON")?;
+        let error = body
+            .get("error")
+            .and_then(|value| value.as_str())
+            .context("read error")?;
+        assert!(error.contains(ERR_MTLS_REQUIRED));
         server.shutdown.notify_one();
         server.shutdown.notified().await;
         Ok(())


### PR DESCRIPTION
## Summary

- Gates `is_local` and `DISABLE_LOCAL_AUTH_BYPASS_ENV` behind `#[cfg(feature = "auth-jwt")]` and removes the loopback bypass branches from the `auth-mtls` `graphql_handler` and `graphql_ws_handler` in `src/lib.rs`. Loopback callers under `auth-mtls` are now subject to the same peer-cert + JWT validation as any other peer, closing a path where unauthenticated loopback callers could be promoted to `RoleGuard::Local` and reach guards like `reset_admin_password` or the `users_customers` customer-scope shortcut.
- Annotates `RoleGuard::Local` with `#[cfg_attr(not(feature = "auth-jwt"), allow(dead_code))]` since the variant is still referenced by guards that compile under both features but is only constructed on the `auth-jwt` bypass path.
- Drops the `set_var("REVIEW_WEB_DISABLE_LOCAL_AUTH_BYPASS", "1")` workaround from `tests/mtls_integration.rs` (the override that masked the defect) and extends the no-identity test to assert `ERR_MTLS_REQUIRED` is returned.
- Adds a `### Changed` entry to `CHANGELOG.md` describing the scoping change and noting the env var is now a no-op under `auth-mtls`.

Closes #840

## Test plan

- [x] `cargo clippy --no-default-features --features auth-jwt --all-targets -- -D warnings`
- [x] `cargo clippy --no-default-features --features auth-mtls --all-targets -- -D warnings`
- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate`
- [x] `cargo test --no-default-features --features auth-jwt`
- [x] `cargo test --no-default-features --features auth-mtls`
- [x] `markdownlint-cli2 "**/*.md" "#target"`
- [x] `auth-mtls` request from a loopback peer without a valid peer cert returns `ERR_MTLS_REQUIRED` rather than a `RoleGuard::Local` admin window.
- [x] `auth-mtls` request with a valid peer cert + JWT continues to run resolvers as `RoleGuard::Role(...)`.
- [x] `auth-jwt` builds preserve existing `is_local` / env-var semantics (no behavior change).