### PR TITLE
Bump review-database to 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   mTLS peer-cert + JWT validation as any other peer. Operators who set
   this env as a workaround can drop it after upgrade. `auth-jwt`
   semantics are unchanged.
+- Bumped `review-database` dependency to 0.45.0, which makes node
+  `Table::update` fully atomic across the Node, Agent, and ExternalService
+  tables and changes its return type from `Result<()>` to `Result<Node>`.
+  No GraphQL contract changes; the returned `Node` is intentionally not
+  wired through the resolvers in this revision and will be consumed in a
+  follow-up that splits `applyNode` into `applyNodeDraft` and
+  `applyAgentConfig`.
 
 ## [0.31.0] - 2026-04-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ num-traits = "0.2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls-native-roots",
 ] }
-review-database = { git = "https://github.com/aicers/review-database.git", rev = "60d7e3a5f6c23991386b623aa87311efc2493542" }
+review-database = { git = "https://github.com/aicers/review-database.git", tag = "0.45.0" }
 roxy = { git = "https://github.com/aicers/roxy.git", tag = "0.6.0" }
 rustls = { version = "0.23", default-features = false, features = [
   "ring",

--- a/src/graphql/node/control.rs
+++ b/src/graphql/node/control.rs
@@ -317,7 +317,8 @@ async fn update_db(
 
     let old = node.clone().try_into()?;
     let new = update.try_into()?;
-    Ok(map.update(i, &old, &new)?)
+    map.update(i, &old, &new)?;
+    Ok(())
 }
 
 async fn send_customer_change_if_needed(ctx: &Context<'_>, i: u32, node: &NodeInput) {


### PR DESCRIPTION
## Summary

- Bumps `review-database` from a `rev`-pinned commit (`60d7e3a5`, predates the #721 merge) to `tag = "0.45.0"`. Switching from `rev` to `tag` also aligns with the convention used by the other git dependencies in `Cargo.toml` (`roxy`, `vinum`).
- The 0.45.0 release ships two BREAKING changes to `tables::node::Table::update`:
  - Node, Agent, and ExternalService writes are now performed inside a single optimistic transaction. Partial-update intermediate states are no longer observable, eliminating a residue path that the previous implementation exposed when an agent or external-service write failed after the node-inner write had already committed.
  - Return type changed from `Result<()>` to `Result<Node>`. The post-update `Node` is assembled inside the successfully-committed transaction.
- Adjusts the two production call sites to compile against the new signature without changing observable behavior:
  - `src/graphql/node/control.rs` — `update_db` discards the returned `Node` so the resolver's existing post-commit `get_by_id` readback for hostname stays in place.
  - `src/graphql/node/crud.rs` — already uses statement-form `?`, no source change needed; only the propagated `Ok` type changes from `()` to `Node`, which the discarding call site handles.
- Intentionally does **not** wire the returned `Node` into either resolver. That belongs to #835 (`applyNodeDraft` + `applyAgentConfig`); doing both in one PR would conflate a dependency upgrade with a feature change.
- GraphQL contracts for `applyNode` and `updateNode` are unchanged.

## Test plan

- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate`
- [x] `cargo clippy --no-default-features --features auth-jwt --all-targets -- -D warnings`
- [x] `cargo clippy --no-default-features --features auth-mtls --all-targets -- -D warnings`
- [x] `cargo test --no-default-features --features auth-jwt` (374 passed)
- [x] `cargo test --no-default-features --features auth-mtls` (11 passed)
- [x] `markdownlint-cli2 "**/*.md" "#target"` (0 errors)

Closes #849