### PR TITLE
Bump version to 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.32.0] - 2026-05-10
 
 ### Added
@@ -1600,7 +1598,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - An initial version.
 
-[Unreleased]: https://github.com/aicers/review-web/compare/0.32.0...main
 [0.32.0]: https://github.com/aicers/review-web/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/aicers/review-web/compare/0.30.1...0.31.0
 [0.30.1]: https://github.com/aicers/review-web/compare/0.30.0...0.30.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-05-10
+
 ### Added
 
 - Added `event(id: ID!): Event` GraphQL query for single-event lookup by an
@@ -1598,7 +1600,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - An initial version.
 
-[Unreleased]: https://github.com/aicers/review-web/compare/0.31.0...main
+[Unreleased]: https://github.com/aicers/review-web/compare/0.32.0...main
+[0.32.0]: https://github.com/aicers/review-web/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/aicers/review-web/compare/0.30.1...0.31.0
 [0.30.1]: https://github.com/aicers/review-web/compare/0.30.0...0.30.1
 [0.30.0]: https://github.com/aicers/review-web/compare/0.29.4...0.30.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-web"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Bumps the crate version to 0.32.0 and stamps the [Unreleased] changelog section with the 0.32.0 release date.

The release packages the changes accumulated since 0.31.0:

- New GraphQL APIs: `event(id)`, `eventListWithTriage`, `customerSensorList`, `applyNodeDraft` / `applyAgentConfig`, and the `accountLockoutPolicy` query plus `updateAccountLockoutPolicy` mutation.
- Configurable account lockout / suspension thresholds replacing the hard-coded 5 attempts / 30 minutes.
- `review-database` bump to 0.45.0 (atomic node `Table::update`, optional `Confidence::threat_category`).
- Scoping of `REVIEW_WEB_DISABLE_LOCAL_AUTH_BYPASS` and the `is_local` loopback bypass to the `auth-jwt` build only.
- Rename of `BlocklistRadius.id` to `packetId` so the new `Event.id` interface field can claim `id`.

Closes #855