### PR TITLE
Replace agentKey with nodeId on customerSensorList Sensor (#858)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Replaced `agentKey` on the `customerSensorList` `Sensor` type with
+  `nodeId: ID!`, and switched the result grain to one row per node. The shape
+  is now `Sensor { customerId, nodeId, hostFqdn }`. Each `nodeId` is the
+  parent node's database ID rendered as a string and is directly substitutable
+  into `EventListFilterInput.sensors`. Pagination cursors now order by
+  `hostFqdn` with `nodeId` as a tiebreak.
+- Widened the role guard on `customerSensorList` to
+  `SystemAdministrator | SecurityAdministrator | SecurityManager |
+  SecurityMonitor` so Detection-side BFF callers can populate a sensor
+  selector without falling back to `nodeList`. Customer-scope enforcement on
+  the `customerIds` argument is unchanged.
+- Tightened `eventList(filter: { sensors: [...] })` to enforce the caller's
+  customer scope on the explicit-sensors path. Supplying a `nodeId` whose
+  owning customer falls outside the caller's accessible scope now returns a
+  `Forbidden` authorization error instead of leaking events for that node's
+  hostname. Unscoped (administrator) callers retain full access. The
+  implicit (no-`sensors`) path is unchanged.
+
 ## [0.32.0] - 2026-05-10
 
 ### Added

--- a/src/graphql/event.rs
+++ b/src/graphql/event.rs
@@ -1267,8 +1267,10 @@ fn from_filter_input(
     };
 
     let sensors = if let Some(sensors_input) = &input.sensors {
+        let scope = crate::graphql::customer_access::users_customers(ctx)
+            .map_err(|e| anyhow!("{}", e.message))?;
         let map = store.node_map();
-        Some(convert_sensors(&map, sensors_input)?)
+        Some(convert_sensors(&map, sensors_input, scope.as_deref())?)
     } else {
         match ctx
             .data::<String>()
@@ -1421,7 +1423,11 @@ fn internal_customer_networks(
     Ok(customer_networks)
 }
 
-fn convert_sensors(map: &database::NodeTable, sensors: &[ID]) -> anyhow::Result<Vec<String>> {
+fn convert_sensors(
+    map: &database::NodeTable,
+    sensors: &[ID],
+    users_customers: Option<&[u32]>,
+) -> anyhow::Result<Vec<String>> {
     let mut converted_sensors: Vec<String> = Vec::with_capacity(sensors.len());
     for id in sensors {
         let i = id
@@ -1431,6 +1437,17 @@ fn convert_sensors(map: &database::NodeTable, sensors: &[ID]) -> anyhow::Result<
         let Some((node, _invalid_agents, _invalid_external_services)) = map.get_by_id(i)? else {
             bail!("no such sensor")
         };
+
+        if let Some(allowed) = users_customers {
+            let customer_id = node
+                .profile
+                .as_ref()
+                .map(|profile| profile.customer_id)
+                .ok_or_else(|| anyhow!("Forbidden"))?;
+            if !allowed.contains(&customer_id) {
+                bail!("Forbidden");
+            }
+        }
 
         if let Some(node_profile) = node.profile
             && !node_profile.hostname.is_empty()
@@ -2113,7 +2130,7 @@ mod tests {
         },
     };
 
-    use crate::graphql::TestSchema;
+    use crate::graphql::{Role, TestSchema};
 
     /// Creates an event message at `timestamp` with the given sensor and
     /// destination `IPv4` addresses.
@@ -2244,8 +2261,6 @@ mod tests {
 
     #[tokio::test]
     async fn event_lookup_respects_tenant_scope() {
-        use crate::graphql::Role;
-
         let schema = TestSchema::new().await;
 
         let res = schema
@@ -2938,6 +2953,84 @@ mod tests {
             res.data.to_string(),
             r#"{eventList: {edges: [{node: {time: "2018-01-27T18:30:09.453829+00:00", sensor: "sensor1"}}], totalCount: "1"}}"#
         );
+    }
+
+    #[tokio::test]
+    async fn explicit_sensors_outside_scope_returns_forbidden() {
+        let schema = TestSchema::new().await;
+
+        // Insert and apply a sensor node owned by customer 0.
+        let _ = schema
+            .execute_as_system_admin(
+                r#"mutation {
+                    insertNode(
+                        name: "sensor1",
+                        customerId: 0,
+                        description: "",
+                        hostname: "sensor1",
+                        agents: [{
+                            key: "sensor"
+                            kind: SENSOR
+                            status: ENABLED
+                        }],
+                        externalServices: [],
+                    )
+                }"#,
+            )
+            .await;
+        let _ = schema
+            .execute_as_system_admin(
+                r#"mutation {
+                    applyNode(
+                        id: "0"
+                        node: {
+                            name: "sensor1",
+                            nameDraft: "sensor1",
+                            profile: null,
+                            profileDraft: {
+                                customerId: 0,
+                                description: "",
+                                hostname: "sensor1",
+                            }
+                            agents: [
+                                {
+                                    key: "sensor",
+                                    kind: "SENSOR",
+                                    status: "ENABLED"
+                                }
+                            ],
+                            externalServices: []
+                        }
+                    )
+                }"#,
+            )
+            .await;
+
+        // Caller scoped to customer 1 (out of scope for sensor node 0) must be
+        // rejected when supplying `sensors: [0]`.
+        let res = schema
+            .execute_as_scoped_user(
+                "{ eventList(filter: { sensors: [0] }) { edges { node { ... on DnsCovertChannel { sensor } } } totalCount } }",
+                Role::SecurityMonitor,
+                Some(vec![1]),
+            )
+            .await;
+        assert_eq!(res.errors.len(), 1, "errors: {:?}", res.errors);
+        assert!(
+            res.errors[0].message.contains("Forbidden"),
+            "message: {}",
+            res.errors[0].message
+        );
+
+        // Caller scoped to customer 0 (in scope) succeeds.
+        let res = schema
+            .execute_as_scoped_user(
+                "{ eventList(filter: { sensors: [0] }) { totalCount } }",
+                Role::SecurityMonitor,
+                Some(vec![0]),
+            )
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
     }
 
     #[tokio::test]

--- a/src/graphql/node/crud.rs
+++ b/src/graphql/node/crud.rs
@@ -53,12 +53,13 @@ impl NodeQuery {
         Ok(node.into())
     }
 
-    /// A list of sensors deployed across customers the caller can access.
-    ///
-    /// A sensor is an entry in `Node.agents` whose `kind` is `SENSOR` and
-    /// whose `config` is set. Nodes whose `profile` is `None` are excluded.
+    /// A list of nodes that have at least one deployed sensor agent
+    /// (`SENSOR`-kind agent with `config` set), scoped to customers the caller
+    /// can access. Nodes whose `profile` is `None` are excluded.
     #[graphql(guard = "RoleGuard::new(Role::SystemAdministrator)
-        .or(RoleGuard::new(Role::SecurityAdministrator))")]
+        .or(RoleGuard::new(Role::SecurityAdministrator))
+        .or(RoleGuard::new(Role::SecurityManager))
+        .or(RoleGuard::new(Role::SecurityMonitor))")]
     async fn customer_sensor_list(
         &self,
         ctx: &Context<'_>,

--- a/src/graphql/node/customer_sensor_list.rs
+++ b/src/graphql/node/customer_sensor_list.rs
@@ -74,10 +74,22 @@ fn validate_customer_ids(
     Ok(Some(parsed))
 }
 
+/// Builds a pagination cursor whose bytewise ordering matches the
+/// `(host_fqdn, node_id)` tuple ordering.
+///
+/// The terminator byte `0x00` separates the hostname from the big-endian
+/// node ID. Because hostnames per RFC 1123 are restricted to letters,
+/// digits, `-`, and `.` (none of which is `0x00`), the terminator never
+/// occurs inside `host_fqdn` and is strictly less than every byte that
+/// can. This makes the cursor of `("a", _)` sort before `("aa", _)`
+/// regardless of node ID — matching the documented sort order — and
+/// keeps `after`/`before` window filtering consistent with that order.
 fn cursor_for(host_fqdn: &str, node_id: u32) -> Vec<u8> {
+    const TERMINATOR: u8 = 0x00;
     let host_bytes = host_fqdn.as_bytes();
-    let mut cursor = Vec::with_capacity(host_bytes.len() + 4);
+    let mut cursor = Vec::with_capacity(host_bytes.len() + 1 + 4);
     cursor.extend_from_slice(host_bytes);
+    cursor.push(TERMINATOR);
     cursor.extend_from_slice(&node_id.to_be_bytes());
     cursor
 }
@@ -777,6 +789,114 @@ mod tests {
             data["customerSensorList"]["pageInfo"]["hasNextPage"],
             json!(false)
         );
+    }
+
+    #[tokio::test]
+    async fn prefix_hostnames_preserve_sort_order() {
+        let schema = TestSchema::new().await;
+        {
+            let store = schema.store();
+            // "a" is a strict prefix of "aa". Tuple ordering requires the row
+            // for "a" to sort before any row for "aa", regardless of node ID.
+            // Insert "aa" first so its node ID is smaller than the one for
+            // "a"; this catches a regression where the cursor concatenated the
+            // hostname bytes with node_id.to_be_bytes() and let the first byte
+            // of the node ID be compared against the next hostname byte.
+            insert_node(
+                &store,
+                "node-aa",
+                Some(profile(1, "aa.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@aa.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+            insert_node(
+                &store,
+                "node-a",
+                Some(profile(1, "a.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@a.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+        }
+
+        let res = schema
+            .execute_as_system_admin(
+                r"{customerSensorList(first: 10) { edges { node { hostFqdn } } } }",
+            )
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 2);
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
+        assert_eq!(edges[1]["node"]["hostFqdn"], "aa.example.com");
+    }
+
+    #[tokio::test]
+    async fn prefix_hostnames_paginate_with_after_cursor() {
+        let schema = TestSchema::new().await;
+        {
+            let store = schema.store();
+            insert_node(
+                &store,
+                "node-aa",
+                Some(profile(1, "aa.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@aa.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+            insert_node(
+                &store,
+                "node-a",
+                Some(profile(1, "a.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@a.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+        }
+
+        let res = schema
+            .execute_as_system_admin(
+                r"{customerSensorList(first: 1) { edges { cursor node { hostFqdn } } pageInfo { endCursor hasNextPage } } }",
+            )
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
+        let end_cursor = data["customerSensorList"]["pageInfo"]["endCursor"]
+            .as_str()
+            .expect("endCursor")
+            .to_string();
+
+        let res = schema
+            .execute_as_system_admin(&format!(
+                r#"{{customerSensorList(first: 10, after: "{end_cursor}") {{ edges {{ node {{ hostFqdn }} }} }} }}"#
+            ))
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["node"]["hostFqdn"], "aa.example.com");
     }
 
     #[tokio::test]

--- a/src/graphql/node/customer_sensor_list.rs
+++ b/src/graphql/node/customer_sensor_list.rs
@@ -1,22 +1,24 @@
 use async_graphql::{
-    Context, Object, Result, SimpleObject, StringNumber,
+    Context, ID, Object, Result, SimpleObject, StringNumber,
     connection::{Connection, Edge, EmptyFields, OpaqueCursor},
 };
 use review_database::event::Direction;
 
 use super::super::customer_access::{is_member, users_customers};
 
-/// A sensor agent that has been deployed (i.e. its `config` is set) on a node
-/// belonging to a particular customer.
+/// A node belonging to a customer that has at least one deployed sensor agent
+/// (a `SENSOR`-kind agent whose `config` is set).
 #[derive(SimpleObject)]
 pub(super) struct Sensor {
     /// The ID of the owning customer.
     customer_id: i32,
 
-    /// The agent key (e.g., `agent@hostname`).
-    agent_key: String,
+    /// The ID of the node this sensor runs on. Substitute directly into
+    /// `EventListFilterInput.sensors`.
+    node_id: ID,
 
     /// The fully-qualified hostname of the host on which the sensor runs.
+    /// Equal to `Event.sensor` for events emitted by this sensor.
     host_fqdn: String,
 }
 
@@ -72,6 +74,14 @@ fn validate_customer_ids(
     Ok(Some(parsed))
 }
 
+fn cursor_for(host_fqdn: &str, node_id: u32) -> Vec<u8> {
+    let host_bytes = host_fqdn.as_bytes();
+    let mut cursor = Vec::with_capacity(host_bytes.len() + 4);
+    cursor.extend_from_slice(host_bytes);
+    cursor.extend_from_slice(&node_id.to_be_bytes());
+    cursor
+}
+
 fn collect_sensors(
     ctx: &Context<'_>,
     customer_ids: Option<&[u32]>,
@@ -89,26 +99,23 @@ fn collect_sensors(
         {
             continue;
         }
+        let has_configured_sensor = node.agents.iter().any(|agent| {
+            agent.kind == review_database::AgentKind::Sensor && agent.config.is_some()
+        });
+        if !has_configured_sensor {
+            continue;
+        }
         let customer_id =
             i32::try_from(profile.customer_id).map_err(|_| "customer ID exceeds Int range")?;
-        for agent in &node.agents {
-            if agent.kind != review_database::AgentKind::Sensor {
-                continue;
-            }
-            if agent.config.is_none() {
-                continue;
-            }
-            let agent_key = agent.key.clone();
-            let cursor = agent_key.as_bytes().to_vec();
-            sensors.push((
-                cursor,
-                Sensor {
-                    customer_id,
-                    agent_key,
-                    host_fqdn: profile.hostname.clone(),
-                },
-            ));
-        }
+        let cursor = cursor_for(&profile.hostname, node.id);
+        sensors.push((
+            cursor,
+            Sensor {
+                customer_id,
+                node_id: ID(node.id.to_string()),
+                host_fqdn: profile.hostname.clone(),
+            },
+        ));
     }
     sensors.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     Ok(sensors)
@@ -218,7 +225,7 @@ mod tests {
         }
     }
 
-    const QUERY: &str = r"{customerSensorList(first: 10) { totalCount edges { node { customerId agentKey hostFqdn } } } }";
+    const QUERY: &str = r"{customerSensorList(first: 10) { totalCount edges { node { customerId nodeId hostFqdn } } } }";
 
     #[tokio::test]
     async fn admin_sees_all_sensors() {
@@ -292,7 +299,7 @@ mod tests {
     #[tokio::test]
     async fn includes_sensor_with_empty_config() {
         let schema = TestSchema::new().await;
-        {
+        let node_id = {
             let store = schema.store();
             // Sensor with config = Some(""): must be included (empty TOML is valid).
             insert_node(
@@ -306,15 +313,15 @@ mod tests {
                     Some(""),
                     None,
                 )],
-            );
-        }
+            )
+        };
 
         let res = schema.execute_as_system_admin(QUERY).await;
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@empty.example.com");
+        assert_eq!(edges[0]["node"]["nodeId"], json!(node_id.to_string()));
         assert_eq!(edges[0]["node"]["customerId"], json!(7));
         assert_eq!(edges[0]["node"]["hostFqdn"], "empty.example.com");
     }
@@ -378,7 +385,43 @@ mod tests {
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@mixed.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "mixed.example.com");
+    }
+
+    #[tokio::test]
+    async fn collapses_multiple_sensor_agents_to_one_row() {
+        let schema = TestSchema::new().await;
+        {
+            let store = schema.store();
+            insert_node(
+                &store,
+                "dual-sensor",
+                Some(profile(1, "dual.example.com")),
+                None,
+                vec![
+                    agent(
+                        AgentKind::Sensor,
+                        "piglet-a@dual.example.com",
+                        Some(""),
+                        None,
+                    ),
+                    agent(
+                        AgentKind::Sensor,
+                        "piglet-b@dual.example.com",
+                        Some(""),
+                        None,
+                    ),
+                ],
+            );
+        }
+
+        let res = schema.execute_as_system_admin(QUERY).await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["node"]["hostFqdn"], "dual.example.com");
+        assert_eq!(data["customerSensorList"]["totalCount"], json!("1"));
     }
 
     #[tokio::test]
@@ -419,7 +462,78 @@ mod tests {
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@a.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
+        assert_eq!(edges[0]["node"]["customerId"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn security_manager_can_call_customer_sensor_list() {
+        let schema = TestSchema::new().await;
+        {
+            let store = schema.store();
+            insert_node(
+                &store,
+                "node-a",
+                Some(profile(1, "a.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@a.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+        }
+
+        let res = schema
+            .execute_as_scoped_user(QUERY, Role::SecurityManager, Some(vec![1]))
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
+    }
+
+    #[tokio::test]
+    async fn security_monitor_can_call_customer_sensor_list() {
+        let schema = TestSchema::new().await;
+        {
+            let store = schema.store();
+            insert_node(
+                &store,
+                "node-a",
+                Some(profile(1, "a.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@a.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+            insert_node(
+                &store,
+                "node-b",
+                Some(profile(2, "b.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@b.example.com",
+                    Some(""),
+                    None,
+                )],
+            );
+        }
+
+        let res = schema
+            .execute_as_scoped_user(QUERY, Role::SecurityMonitor, Some(vec![1]))
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
         assert_eq!(edges[0]["node"]["customerId"], json!(1));
     }
 
@@ -444,7 +558,7 @@ mod tests {
 
         let res = schema
             .execute_as_scoped_user(
-                r"{customerSensorList(customerIds: [1, 2], first: 10) { totalCount edges { node { agentKey } } } }",
+                r"{customerSensorList(customerIds: [1, 2], first: 10) { totalCount edges { node { nodeId } } } }",
                 Role::SecurityAdministrator,
                 Some(vec![1]),
             )
@@ -486,7 +600,7 @@ mod tests {
 
         let res = schema
             .execute_as_scoped_user(
-                r"{customerSensorList(customerIds: [2], first: 10) { totalCount edges { node { agentKey customerId } } } }",
+                r"{customerSensorList(customerIds: [2], first: 10) { totalCount edges { node { hostFqdn customerId } } } }",
                 Role::SecurityAdministrator,
                 Some(vec![1, 2]),
             )
@@ -495,7 +609,7 @@ mod tests {
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@b.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "b.example.com");
         assert_eq!(edges[0]["node"]["customerId"], json!(2));
     }
 
@@ -532,14 +646,43 @@ mod tests {
 
         let res = schema
             .execute_as_system_admin(
-                r"{customerSensorList(customerIds: [1], first: 10) { totalCount edges { node { agentKey } } } }",
+                r"{customerSensorList(customerIds: [1], first: 10) { totalCount edges { node { hostFqdn } } } }",
             )
             .await;
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@a.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
+    }
+
+    #[tokio::test]
+    async fn node_id_round_trips_to_u32() {
+        let schema = TestSchema::new().await;
+        let inserted_id = {
+            let store = schema.store();
+            insert_node(
+                &store,
+                "node-rt",
+                Some(profile(1, "rt.example.com")),
+                None,
+                vec![agent(
+                    AgentKind::Sensor,
+                    "piglet@rt.example.com",
+                    Some(""),
+                    None,
+                )],
+            )
+        };
+
+        let res = schema.execute_as_system_admin(QUERY).await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let edges = data["customerSensorList"]["edges"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        let node_id_str = edges[0]["node"]["nodeId"].as_str().expect("nodeId string");
+        let parsed: u32 = node_id_str.parse().expect("nodeId must parse as u32");
+        assert_eq!(parsed, inserted_id);
     }
 
     fn seed_three_sensors(schema: &TestSchema) {
@@ -571,15 +714,15 @@ mod tests {
 
         let res = schema
             .execute_as_system_admin(
-                r"{customerSensorList(first: 2) { totalCount edges { cursor node { agentKey } } pageInfo { endCursor hasNextPage hasPreviousPage } } }",
+                r"{customerSensorList(first: 2) { totalCount edges { cursor node { hostFqdn } } pageInfo { endCursor hasNextPage hasPreviousPage } } }",
             )
             .await;
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 2);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@a.example.com");
-        assert_eq!(edges[1]["node"]["agentKey"], "piglet@b.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "a.example.com");
+        assert_eq!(edges[1]["node"]["hostFqdn"], "b.example.com");
         assert_eq!(data["customerSensorList"]["totalCount"], json!("3"));
         assert_eq!(
             data["customerSensorList"]["pageInfo"]["hasNextPage"],
@@ -596,14 +739,14 @@ mod tests {
             .to_string();
         let res = schema
             .execute_as_system_admin(&format!(
-                r#"{{customerSensorList(first: 2, after: "{end_cursor}") {{ edges {{ node {{ agentKey }} }} pageInfo {{ hasNextPage }} }} }}"#
+                r#"{{customerSensorList(first: 2, after: "{end_cursor}") {{ edges {{ node {{ hostFqdn }} }} pageInfo {{ hasNextPage }} }} }}"#
             ))
             .await;
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@c.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "c.example.com");
         assert_eq!(
             data["customerSensorList"]["pageInfo"]["hasNextPage"],
             json!(false)
@@ -617,15 +760,15 @@ mod tests {
 
         let res = schema
             .execute_as_system_admin(
-                r"{customerSensorList(last: 2) { edges { node { agentKey } } pageInfo { hasNextPage hasPreviousPage } } }",
+                r"{customerSensorList(last: 2) { edges { node { hostFqdn } } pageInfo { hasNextPage hasPreviousPage } } }",
             )
             .await;
         assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
         let data = res.data.into_json().unwrap();
         let edges = data["customerSensorList"]["edges"].as_array().unwrap();
         assert_eq!(edges.len(), 2);
-        assert_eq!(edges[0]["node"]["agentKey"], "piglet@b.example.com");
-        assert_eq!(edges[1]["node"]["agentKey"], "piglet@c.example.com");
+        assert_eq!(edges[0]["node"]["hostFqdn"], "b.example.com");
+        assert_eq!(edges[1]["node"]["hostFqdn"], "c.example.com");
         assert_eq!(
             data["customerSensorList"]["pageInfo"]["hasPreviousPage"],
             json!(true)
@@ -634,5 +777,21 @@ mod tests {
             data["customerSensorList"]["pageInfo"]["hasNextPage"],
             json!(false)
         );
+    }
+
+    #[tokio::test]
+    async fn schema_does_not_expose_agent_key_on_sensor() {
+        let schema = TestSchema::new().await;
+        let res = schema
+            .execute_as_system_admin(r#"{ __type(name: "Sensor") { fields { name } } }"#)
+            .await;
+        assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+        let data = res.data.into_json().unwrap();
+        let fields = data["__type"]["fields"].as_array().expect("fields array");
+        let names: Vec<&str> = fields.iter().filter_map(|f| f["name"].as_str()).collect();
+        assert!(names.contains(&"customerId"));
+        assert!(names.contains(&"nodeId"));
+        assert!(names.contains(&"hostFqdn"));
+        assert!(!names.contains(&"agentKey"));
     }
 }


### PR DESCRIPTION
## Summary

- Replace `agentKey` on `customerSensorList`'s `Sensor` with `nodeId: ID!` and switch the result grain to one row per Node, so callers can substitute the value directly into `EventListFilterInput.sensors`. The pagination cursor becomes `hostFqdn` bytes with the node ID as a tiebreak, preserving alphabetical ordering and staying unique per emitted row.
- Widen the `customerSensorList` role guard to `SystemAdministrator | SecurityAdministrator | SecurityManager | SecurityMonitor` so Detection-side BFF callers can reach it. `validate_customer_ids` continues to constrain tenant-scoped users to their accessible customers.
- Tighten `eventList(filter: { sensors: [...] })` to enforce the caller's customer scope on the explicit-sensors path. Out-of-scope node IDs now return a `Forbidden` authorization error instead of leaking events for that node's hostname; unscoped admin callers are unaffected.
- Document the breaking field swap, role-guard widening, and `eventList` scope tightening under a new `## [Unreleased]` section in `CHANGELOG.md`.

Closes #858

## Test plan

- [x] `Sensor` exposes exactly `customerId`, `nodeId`, `hostFqdn`; `agentKey` is no longer in the schema (introspection test).
- [x] `nodeId` round-trips: parses as `u32` and equals the inserted Node's database ID.
- [x] A Node with two configured SENSOR-kind agents produces exactly one row in `customerSensorList`.
- [x] Pagination cursors are unique per row and preserve alphabetical-by-`hostFqdn` ordering (existing `first`/`after`/`last` tests updated to use `nodeId`/`hostFqdn`).
- [x] `customerSensorList` is callable by `SystemAdministrator`, `SecurityAdministrator`, `SecurityManager`, and `SecurityMonitor`; tenant-scoped callers still see only sensors of accessible customers.
- [x] `eventList(filter: { sensors: [...] })` returns `Forbidden` when any supplied `nodeId` lies outside the caller's customer scope; unscoped admin callers are unaffected.
- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` passes.
- [x] `cargo clippy --no-default-features --features auth-jwt --all-targets -- -D warnings` passes.
- [x] `cargo clippy --no-default-features --features auth-mtls --all-targets -- -D warnings` passes.
- [x] `cargo test --no-default-features --features auth-jwt` passes (401 tests).
- [x] `cargo test --no-default-features --features auth-mtls` passes (332 lib + 11 mTLS integration tests; verified locally and in CI).
- [x] `markdownlint-cli2 "**/*.md" "#target"` passes.