### PR TITLE
Bump version to 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.33.0] - 2026-05-11
 
 ### Changed
 
@@ -1620,6 +1620,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - An initial version.
 
+[0.33.0]: https://github.com/aicers/review-web/compare/0.32.0...0.33.0
 [0.32.0]: https://github.com/aicers/review-web/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/aicers/review-web/compare/0.30.1...0.31.0
 [0.30.1]: https://github.com/aicers/review-web/compare/0.30.0...0.30.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-web"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Releases the changes accumulated in `[Unreleased]` since 0.32.0:

- `customerSensorList` `Sensor` field swap (`agentKey` → `nodeId: ID!`) with per-node result grain and updated pagination cursor (breaking).
- `customerSensorList` role guard widened to `SystemAdministrator | SecurityAdministrator | SecurityManager | SecurityMonitor`.
- `eventList(filter: { sensors: [...] })` now returns `Forbidden` when any `nodeId` falls outside the caller's customer scope.

Cuts `0.33.0` (minor bump under SemVer 0.x because of the breaking field swap and the behavior change on the explicit-sensors path).

Part of #860

## Test plan

- [x] `Cargo.toml` version bumped to `0.33.0`.
- [x] `CHANGELOG.md` `[Unreleased]` promoted to `[0.33.0] - 2026-05-11` with the matching compare link added.
- [ ] After merge: tag `0.33.0` (annotated) and push the tag.